### PR TITLE
Add dom driver (Dominode)

### DIFF
--- a/implementations/java/docker-compose.yml
+++ b/implementations/java/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: .
       dockerfile: ./docker/Dockerfile-driver-did-btcr
-      args: 
+      args:
         bitcoinConnection: bitcoind
         rpcUrlMainnet: http://user:pass@172.18.0.1:8332/
         rpcUrlTestnet: http://user:pass@172.18.0.1:18332/
@@ -14,7 +14,7 @@ services:
     build:
       context: .
       dockerfile: ./docker/Dockerfile-driver-did-sov
-      args: 
+      args:
         libIndyPath: ./sovrin/lib/
         poolConfigName: 11347-04
         poolGenesisTxn: ./sovrin/11347-04.txn
@@ -47,10 +47,15 @@ services:
         etherscanApiKovan: http://api-kovan.etherscan.io/api
     ports:
       - "8085:8085"
+  driver-did-dom:
+    build:
+      context: .
+      dockerfile: ./docker/Dockerfile-driver-did-dom
+    ports:
+      - "8086:8086"
   uni-resolver-web:
     build:
       context: .
       dockerfile: ./docker/Dockerfile-uni-resolver-web
     ports:
       - "8080:8080"
-

--- a/implementations/java/docker/Dockerfile-driver-did-dom
+++ b/implementations/java/docker/Dockerfile-driver-did-dom
@@ -1,0 +1,35 @@
+# Dockerfile
+
+FROM debian:stretch
+MAINTAINER Ricardo Cosme <ricardo.cosme@dominode.com>
+
+USER root
+
+RUN apt-get -y update
+
+RUN apt-get install -y --no-install-recommends openjdk-8-jdk maven
+
+ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64/
+ENV PATH $JAVA_HOME/bin:$PATH
+
+# build dependencies
+
+RUN apt-get install -y --no-install-recommends git
+
+# build driver-did-dom
+
+ADD . /opt/uni-resolver-java
+
+RUN cd /opt/uni-resolver-java && mvn clean
+RUN cd /opt/uni-resolver-java && mvn install -N -DskipTests
+RUN cd /opt/uni-resolver-java/uni-resolver-core && mvn install -N -DskipTests
+RUN cd /opt/uni-resolver-java/driver && mvn install -N -DskipTests
+RUN cd /opt/uni-resolver-java/driver-did-dom && mvn install package -N -DskipTests
+
+# done
+
+RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+EXPOSE 8086
+
+CMD "/opt/uni-resolver-java/docker/run-driver-did-dom.sh"

--- a/implementations/java/docker/run-driver-did-dom.sh
+++ b/implementations/java/docker/run-driver-did-dom.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cd /opt/uni-resolver-java/driver-did-dom/
+mvn jetty:run -P war

--- a/implementations/java/driver-did-dom/.gitignore
+++ b/implementations/java/driver-did-dom/.gitignore
@@ -1,0 +1,5 @@
+.project
+.classpath
+/.settings/
+/target
+/bin/

--- a/implementations/java/driver-did-dom/pom.xml
+++ b/implementations/java/driver-did-dom/pom.xml
@@ -1,0 +1,107 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+	<artifactId>uni-resolver-driver-did-dom</artifactId>
+	<packaging>${packaging.type}</packaging>
+	<name>uni-resolver-driver-did-dom</name>
+
+	<parent>
+		<groupId>decentralized-identity</groupId>
+		<artifactId>uni-resolver</artifactId>
+		<version>0.1-SNAPSHOT</version>
+	</parent>
+
+	<profiles>
+
+		<profile>
+
+			<id>default</id>
+			<activation><activeByDefault>true</activeByDefault></activation>
+			<properties><packaging.type>jar</packaging.type></properties>
+
+		</profile>
+
+		<profile>
+
+			<id>war</id>
+			<properties><packaging.type>war</packaging.type></properties>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-war-plugin</artifactId>
+						<version>2.4</version>
+					</plugin>
+					<plugin>
+						<groupId>org.eclipse.jetty</groupId>
+						<artifactId>jetty-maven-plugin</artifactId>
+						<version>9.4.0.M1</version>
+						<configuration>
+							<jettyConfig>
+								${basedir}/src/test/resources/jetty.xml
+							</jettyConfig>
+							<jettyEnvXml>
+								${basedir}/src/test/resources/jetty-env.xml
+							</jettyEnvXml>
+							<contextPath>/</contextPath>
+							<useTestClasspath>true</useTestClasspath>
+							<systemProperties>
+								<systemProperty>
+									<name>jetty.port</name>
+									<value>8086</value>
+								</systemProperty>
+								<systemProperty>
+									<name>slf4j</name>
+									<value>true</value>
+								</systemProperty>
+								<systemProperty>
+									<name>log4j.configuration</name>
+									<value>file:${basedir}/src/test/resources/log4j.properties</value>
+								</systemProperty>
+							</systemProperties>
+						</configuration>
+						<dependencies>
+							<dependency>
+								<groupId>org.slf4j</groupId>
+								<artifactId>slf4j-api</artifactId>
+								<version>1.7.5</version>
+								<scope>compile</scope>
+							</dependency>
+							<dependency>
+								<groupId>org.slf4j</groupId>
+								<artifactId>jcl-over-slf4j</artifactId>
+								<version>1.7.5</version>
+								<scope>compile</scope>
+							</dependency>
+							<dependency>
+								<groupId>org.slf4j</groupId>
+								<artifactId>slf4j-log4j12</artifactId>
+								<version>1.7.5</version>
+								<scope>compile</scope>
+							</dependency>
+						</dependencies>
+					</plugin>
+				</plugins>
+			</build>
+
+		</profile>
+
+	</profiles>
+
+	<dependencies>
+		<dependency>
+			<groupId>decentralized-identity</groupId>
+			<artifactId>uni-resolver-driver</artifactId>
+			<version>0.1-SNAPSHOT</version>
+			<scope>compile</scope>
+         </dependency>
+		<dependency>
+           <groupId>org.json</groupId>
+           <artifactId>json</artifactId>
+           <version>20171018</version>
+			<scope>compile</scope>
+		</dependency>
+	</dependencies>
+
+</project>

--- a/implementations/java/driver-did-dom/src/main/java/uniresolver/driver/did/dom/DidDomDriver.java
+++ b/implementations/java/driver-did-dom/src/main/java/uniresolver/driver/did/dom/DidDomDriver.java
@@ -29,7 +29,7 @@ import uniresolver.result.ResolutionResult;
 
 public class DidDomDriver implements Driver {
     
-    public static final Pattern DID_DOM_PATTERN = Pattern.compile("^did:dom:([123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{33,34})$");
+    public static final Pattern DID_DOM_PATTERN = Pattern.compile("^did:dom:[a-km-zA-HJ-NP-Z1-9]{32,32}$");
     
     private final String DID_DOM_RESOLVER_URL = "https://did-resolver.dominode.com";
     
@@ -45,7 +45,7 @@ public class DidDomDriver implements Driver {
         DIDDOCUMENT_PUBLICKEY_TYPES.put("RsaVerificationKey2018", "publicKeyPem");
         DIDDOCUMENT_PUBLICKEY_TYPES.put("Secp256k1VerificationKey2018", "publicKeyHex");
     }
-
+    
     @Override
     public ResolutionResult resolve(String identifier) throws ResolutionException {
 

--- a/implementations/java/driver-did-dom/src/main/java/uniresolver/driver/did/dom/DidDomDriver.java
+++ b/implementations/java/driver-did-dom/src/main/java/uniresolver/driver/did/dom/DidDomDriver.java
@@ -1,0 +1,227 @@
+package uniresolver.driver.did.dom;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.LaxRedirectStrategy;
+import org.apache.http.util.EntityUtils;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import uniresolver.ResolutionException;
+import uniresolver.did.DIDDocument;
+import uniresolver.did.Authentication;
+import uniresolver.did.PublicKey;
+import uniresolver.did.Service;
+import uniresolver.driver.Driver;
+import uniresolver.result.ResolutionResult;
+
+public class DidDomDriver implements Driver {
+    
+    public static final Pattern DID_DOM_PATTERN = Pattern.compile("^did:dom:([123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{33,34})$");
+    
+    private final String DID_DOM_RESOLVER_URL = "https://did-resolver.dominode.com";
+    
+    public static final HashMap<String, String> DIDDOCUMENT_PUBLICKEY_TYPES = new HashMap<String, String>();
+    public static final String[] DIDDOCUMENT_AUTHENTICATION_TYPES = new String[] { "Ed25519SignatureAuthentication2018", "RsaSignatureAuthentication2018", "Secp256k1SignatureAuthentication2018"};
+
+    public static final HttpClient DEFAULT_HTTP_CLIENT = HttpClientBuilder.create().setRedirectStrategy(new LaxRedirectStrategy()).build();
+
+    private HttpClient httpClient = DEFAULT_HTTP_CLIENT;
+
+    public DidDomDriver() {
+        DIDDOCUMENT_PUBLICKEY_TYPES.put("Ed25519VerificationKey2018", "publicKeyBase58");
+        DIDDOCUMENT_PUBLICKEY_TYPES.put("RsaVerificationKey2018", "publicKeyPem");
+        DIDDOCUMENT_PUBLICKEY_TYPES.put("Secp256k1VerificationKey2018", "publicKeyHex");
+    }
+
+    @Override
+    public ResolutionResult resolve(String identifier) throws ResolutionException {
+
+        // match 
+        Matcher matcher = DID_DOM_PATTERN.matcher(identifier);
+        if(!matcher.matches()) {
+           return null;
+        }
+        
+        // DDO id
+        String id = identifier;        
+
+        // fetch DDO 
+        String nameUri = this.getDomUrl()+ "/ddo/" + identifier;
+        HttpGet httpGet = new HttpGet(nameUri);
+
+        List<PublicKey> publicKeys = new ArrayList<PublicKey> ();
+        List<Authentication> authentications = new ArrayList<Authentication> ();
+        List<Service> services = new ArrayList<Service> ();
+        
+        try (CloseableHttpResponse httpResponse = (CloseableHttpResponse) this.getHttpClient().execute(httpGet)) {
+
+            if(httpResponse.getStatusLine().getStatusCode() != 200) {
+               throw new ResolutionException("Cannot retrieve DDO for `" + identifier + "` from `" + nameUri + ": " + httpResponse.getStatusLine());
+            }
+
+            // extract payload
+            HttpEntity httpEntity = httpResponse.getEntity();
+            String entityString = EntityUtils.toString(httpEntity);
+            EntityUtils.consume(httpEntity);
+
+            // got to be JSON 
+            JSONObject jo = new JSONObject(entityString);
+
+            if(jo.isNull("publicKey")) {
+               // no public keys defined
+               throw new ResolutionException("Cannot retrieve public key(s) for `" + identifier + "`");
+            }
+            else {
+                 // extract public_key(s)        
+                JSONArray propPublicKey = jo.getJSONArray("publicKey");
+                
+                int keyNum = 0;
+                
+                for (Object itemPubKey: propPublicKey) {
+                    
+                    JSONObject objPubKey = (JSONObject) itemPubKey;
+                    
+                    String lblPublicKey = "";
+                    
+                    String typePublicKey[] = new String[1];
+                    
+                    for (Map.Entry<String, String> entry : DIDDOCUMENT_PUBLICKEY_TYPES.entrySet()) {
+                        if (objPubKey.getString("type").equals(entry.getKey())) {
+                            typePublicKey[0] = entry.getKey();
+                            lblPublicKey = entry.getValue();
+                        }
+                    }
+                                        
+                    String pubKeyValue = objPubKey.getString(lblPublicKey);
+                    String keyId = objPubKey.getString("id");
+                    
+                    if (!keyId.contains("#key")) {
+                        keyId = id + "#key-" + (++keyNum);
+                    }
+                    
+                    PublicKey publicKey;
+                    
+                    switch (typePublicKey[0]) {
+                        case "Ed25519VerificationKey2018":
+                            publicKey = PublicKey.build(keyId, typePublicKey, null, pubKeyValue, null, null);
+                            break;
+                        case "RsaVerificationKey2018":
+                            publicKey = PublicKey.build(keyId, typePublicKey, null, null, null, pubKeyValue);
+                            break;
+                        case "Secp256k1VerificationKey2018":
+                            publicKey = PublicKey.build(keyId, typePublicKey, null, null, pubKeyValue, null);
+                            break;
+                        default:
+                            publicKey = null;
+                            break;
+                    }
+                    
+                    if (publicKey != null) {
+                        publicKeys.add(publicKey);
+                    }
+                    
+                }
+            }
+
+            if(jo.isNull("authentication")) {
+               // no authentication(s) defined
+               throw new ResolutionException("Cannot retrieve authentication for `" + identifier + "`");
+            }
+            else {
+                 // extract authentication(s)        
+                JSONArray propAuthentication = jo.getJSONArray("authentication");
+                
+                int keyNum = 0;
+                
+                for (Object itemAuthentication: propAuthentication) {
+                 
+                    JSONObject objAuthentication = (JSONObject) itemAuthentication;
+                    
+                    String typeAuthentication[] = new String[1];
+                    
+                    for (String entry : DIDDOCUMENT_AUTHENTICATION_TYPES) {
+                        if (objAuthentication.getString("type").equals(entry)) {
+                            typeAuthentication[0] = entry;
+                        }
+                    }
+                    
+                    String keyId = objAuthentication.getString("publicKey");
+                    
+                    if (!keyId.contains("#key")) {
+                        keyId = id + "#key-" + (++keyNum);
+                    }
+                    
+                    Authentication authentication = Authentication.build(null, typeAuthentication, keyId);
+                    authentications.add(authentication);
+                }
+                
+            }
+          
+            if (!jo.isNull("service")) {
+                
+                JSONArray propService = jo.getJSONArray("service");
+                
+                for (Object itemService: propService) {
+                    
+                    JSONObject objService = (JSONObject) itemService;
+                    
+                    Service service = Service.build(objService.getString("type"), null, objService.getString("serviceEndpoint"));
+                    services.add(service);
+                }           
+            }
+
+           
+        } catch (IOException ex) {
+            throw new ResolutionException("Cannot retrieve DDO info for `" + identifier + "` from `" + nameUri + "`: " + ex.getMessage(), ex);
+        } catch (JSONException jex) {
+            throw new ResolutionException("Cannot parse JSON response from `" + nameUri + "`: " + jex.getMessage(), jex);
+        }
+        
+        // create DDO
+        DIDDocument didDocument = DIDDocument.build(id, publicKeys, authentications, null, services);
+
+        // done
+        return ResolutionResult.build(didDocument);
+    }
+
+    public Map<String, Object> properties() {
+
+    	Map<String, Object> properties = new HashMap<String, Object> ();
+    	properties.put("domUrl", this.getDomUrl());
+    	
+    	return properties;
+    }
+    
+    /*
+     * Getters and setters
+     */
+
+    public HttpClient getHttpClient() {
+
+        return this.httpClient;
+    }
+
+    public void setHttpClient(HttpClient httpClient) {
+
+        this.httpClient = httpClient;
+    }
+
+    public String getDomUrl() { 
+
+       return this.DID_DOM_RESOLVER_URL;
+    }
+
+}

--- a/implementations/java/driver-did-dom/src/main/java/uniresolver/driver/did/dom/DidDomDriver.java
+++ b/implementations/java/driver-did-dom/src/main/java/uniresolver/driver/did/dom/DidDomDriver.java
@@ -29,7 +29,7 @@ import uniresolver.result.ResolutionResult;
 
 public class DidDomDriver implements Driver {
     
-    public static final Pattern DID_DOM_PATTERN = Pattern.compile("^did:dom:[a-km-zA-HJ-NP-Z1-9]{32,32}$");
+    public static final Pattern DID_DOM_PATTERN = Pattern.compile("^did:dom:[a-km-zA-HJ-NP-Z1-9]{30,30}$");
     
     private final String DID_DOM_RESOLVER_URL = "https://did-resolver.dominode.com";
     

--- a/implementations/java/driver-did-dom/src/main/webapp/WEB-INF/web.xml
+++ b/implementations/java/driver-did-dom/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns="http://java.sun.com/xml/ns/javaee" xmlns:web="http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
+	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
+	id="WebApp_ID" version="2.5">
+
+	<display-name>uni-resolver-driver-did-dom</display-name>
+
+	<!-- SERVLET -->
+
+	<servlet>
+		<display-name>ResolveServlet</display-name>
+		<servlet-name>ResolveServlet</servlet-name>
+		<servlet-class>uniresolver.driver.servlet.ResolveServlet</servlet-class>
+		<init-param>
+			<param-name>Driver</param-name>
+			<param-value>uniresolver.driver.did.dom.DidDomDriver</param-value>
+		</init-param>
+		<load-on-startup>1</load-on-startup>
+	</servlet>
+	<servlet>
+		<display-name>PropertiesServlet</display-name>
+		<servlet-name>PropertiesServlet</servlet-name>
+		<servlet-class>uniresolver.driver.servlet.PropertiesServlet</servlet-class>
+		<init-param>
+			<param-name>Driver</param-name>
+			<param-value>uniresolver.driver.did.dom.DidDomDriver</param-value>
+		</init-param>
+		<load-on-startup>1</load-on-startup>
+	</servlet>
+	<servlet-mapping>
+		<servlet-name>ResolveServlet</servlet-name>
+		<url-pattern>/1.0/identifiers/*</url-pattern>
+	</servlet-mapping>
+	<servlet-mapping>
+		<servlet-name>PropertiesServlet</servlet-name>
+		<url-pattern>/1.0/properties</url-pattern>
+		<url-pattern>/1.0/properties/*</url-pattern>
+	</servlet-mapping>
+
+</web-app>

--- a/implementations/java/driver-did-dom/src/test/resources/jetty-env.xml
+++ b/implementations/java/driver-did-dom/src/test/resources/jetty-env.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure.dtd">
+<Configure id="JettyWebAppContext" class="org.eclipse.jetty.maven.plugin.JettyWebAppContext">
+	<Call name="setAttribute">
+		<Arg>org.eclipse.jetty.server.webapp.WebInfIncludeJarPattern</Arg>
+		<Arg>^$</Arg>
+	</Call>
+</Configure>

--- a/implementations/java/driver-did-dom/src/test/resources/jetty.xml
+++ b/implementations/java/driver-did-dom/src/test/resources/jetty.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure.dtd">
+<Configure id="JettyServer" class="org.eclipse.jetty.server.Server">
+</Configure>

--- a/implementations/java/driver-did-dom/src/test/resources/log4j.properties
+++ b/implementations/java/driver-did-dom/src/test/resources/log4j.properties
@@ -1,0 +1,11 @@
+log4j.rootLogger=DEBUG, STDOUT
+
+log4j.appender.STDOUT=org.apache.log4j.ConsoleAppender
+log4j.appender.STDOUT.layout=org.apache.log4j.PatternLayout
+log4j.appender.STDOUT.layout.ConversionPattern=%d{HH:mm:ss,SSS} - %5p [%c] - %m%n
+
+log4j.logger.org.apache=INFO, STDOUT
+log4j.logger.org.eclipse=INFO, STDOUT
+log4j.logger.org.mortbay=INFO, STDOUT
+log4j.logger.org.springframework=INFO, STDOUT
+log4j.logger.xdi2=DEBUG, STDOUT

--- a/implementations/java/pom.xml
+++ b/implementations/java/pom.xml
@@ -29,6 +29,7 @@
 		<module>driver-did-btcr</module>
 		<module>driver-did-sov</module>
 		<module>driver-did-erc725</module>
+		<module>driver-did-dom</module>		
 		<module>driver-http</module>
 		<module>examples</module>
 	</modules>

--- a/implementations/java/uni-resolver-web/src/main/webapp/WEB-INF/applicationContext.xml
+++ b/implementations/java/uni-resolver-web/src/main/webapp/WEB-INF/applicationContext.xml
@@ -15,6 +15,7 @@
 				<entry key="did:ipid"><ref bean="DidIpidDriver" /></entry>
 				<entry key="did:stack"><ref bean="DidStackDriver" /></entry>
 				<entry key="did:erc725"><ref bean="DidErc725Driver" /></entry>
+				<entry key="did:dom"><ref bean="DidDomDriver" /></entry>
 			</util:map>
 		</property>
 	</bean>
@@ -91,6 +92,12 @@
 		<property name="resolveUri" value="http://driver-did-erc725:8085/1.0/identifiers/$1" />
 		<property name="propertiesUri" value="http://driver-did-erc725:8085/1.0/properties" />
 		<property name="pattern" value="^(did:erc725:.+)$" />
+	</bean>
+
+	<bean id="DidDomDriver" class="uniresolver.driver.http.HttpDriver">
+		<property name="resolveUri" value="http://driver-did-dom:8086/1.0/identifiers/$1" />
+		<property name="propertiesUri" value="http://driver-did-dom:8086/1.0/properties" />
+		<property name="pattern" value="^(did:dom:.+)$" />
 	</bean>
 
 </beans>


### PR DESCRIPTION
This PR adds Dominode's driver-did-dom to the universal resolver and provides support to resolve the `dom` method (as in did:dom:).

Here are some DID resolving examples for the `dom` method:
```
curl -X GET  http://localhost:8080/1.0/identifiers/did:dom:Jjbfgyu7My4RrbRNrXTPBz4PnhnMEE
curl -X GET  http://localhost:8080/1.0/identifiers/did:dom:JkLLdg7ziwV7CvZjtn3jrQNyfk2cim
```

Any questions / comments shoot!