### PR TITLE
Change docker-compose for swarm deployments / auto-restart, add a run.sh script for easy deployment

### DIFF
--- a/implementations/java/docker-compose.yml
+++ b/implementations/java/docker-compose.yml
@@ -8,6 +8,8 @@ services:
         bitcoinConnection: bitcoind
         rpcUrlMainnet: http://user:pass@172.18.0.1:8332/
         rpcUrlTestnet: http://user:pass@172.18.0.1:18332/
+    image: localhost:5000/driver-did-btcr:latest
+    restart: "always"
     ports:
       - "8081:8081"
   driver-did-sov:
@@ -19,16 +21,21 @@ services:
         poolConfigName: 11347-04
         poolGenesisTxn: ./sovrin/11347-04.txn
         walletName: default
+    image: localhost:5000/driver-did-sov:latest
+    restart: "always"
     ports:
       - "8082:8082"
   driver-did-stack:
     build:
       context: .
       dockerfile: ./docker/Dockerfile-driver-did-stack
+    image: localhost:5000/driver-did-stack:latest
+    restart: "always"
     ports:
       - "8084:8084"
   driver-did-uport:
     image: uport/uni-resolver-driver-did-uport
+    restart: "always"
     ports:
       - "8083:8081"
   driver-did-erc725:
@@ -45,17 +52,23 @@ services:
         etherscanApiRopsten: http://api-ropsten.etherscan.io/api
         etherscanApiRinkeby: http://api-rinkeby.etherscan.io/api
         etherscanApiKovan: http://api-kovan.etherscan.io/api
+    image: localhost:5000/driver-did-erc725:latest
+    restart: "always"
     ports:
       - "8085:8085"
   driver-did-dom:
     build:
       context: .
       dockerfile: ./docker/Dockerfile-driver-did-dom
+    image: localhost:5000/driver-did-dom:latest
+    restart: "always"
     ports:
       - "8086:8086"
   uni-resolver-web:
     build:
       context: .
       dockerfile: ./docker/Dockerfile-uni-resolver-web
+    image: localhost:5000/uni-resolver-web:latest
+    restart: "always"
     ports:
       - "8080:8080"

--- a/implementations/java/run.sh
+++ b/implementations/java/run.sh
@@ -1,0 +1,65 @@
+echo "---------";
+echo "Universal Resolver";
+echo "(c) 2017-2018 Decentralized Identity Foundation, All Rights Reserved.";
+echo "Licensed under the Apache 2.0 License";
+echo "---------";
+sleep 1;
+echo "Checking for docker registry.";
+reg_container=$(docker ps | grep registry | sed 's/   */%/g' | cut -f1 -d '%')
+reg_state=$(docker ps | grep registry | sed 's/   */%/g' | cut -f5 -d '%' | sed 's/  */%/g' | cut -f1 -d '%')
+
+if [ $reg_state != "Up" ]; then
+    echo "Creating a local docker registry server.";
+    docker run -d -p 5000:5000 --restart=always --name registry registry:2
+    if [ $? -eq 0 ]; then
+        echo "Registry server deployed.";
+    else
+        echo "Registry server could not be deployed.";
+        exit 127;
+    fi
+
+fi
+
+echo "Registry exists. Building resolver.";
+docker-compose build
+if [ $? -eq 0 ]; then
+    echo "Build complete.";
+else
+    echo "Build failed.";
+    exit 127;
+fi
+
+echo "Publishing images to local registry server."
+docker-compose push
+if [ $? -eq 0 ]; then
+    echo "Local publish complete.";
+else
+    echo "Local publish failed.";
+    exit 127;
+fi
+
+
+echo "Checking for swarm configuration.";
+$(docker stack ls) >> /dev/null
+if [ $? -eq 1 ]; then
+    echo "Swarm is not running. Starting a new docker swarm."
+    docker swarm init
+    if [ $? -eq 0 ]; then
+        echo "Swarm online.";
+    else
+        echo "Swarm could not be started.";
+        exit 127;
+    fi
+
+fi
+
+echo "Deploying resolver to swarm".
+docker stack deploy --compose-file=./docker-compose.yml dev
+if [ $? -eq 0 ]; then
+    echo "Deployment complete (deployed to dev stack).";
+else
+    echo "Deployment failed.";
+    exit 127;
+fi
+
+echo "done"


### PR DESCRIPTION
Change docker-compose for swarm deployments / auto-restart, add a run.sh script for easy deployment
I've added image references to each entry for docker-compose so that the docker-compose builder can build the images first, publish them to a local registry, then deploy them in swarm configuration across a swarm network. The run.sh script should set up everything that needs to be set up:
1. creates a local registry server if it doesn't already exist
2. initializes swarm mode if needed
3. builds the resolver images
4. publishes the resolver images to local registry
5. deploys the resolver via "dev" stack over a swarm/overlay network