### PR TITLE
Add HACERA's did:hcr driver configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Are you developing a DID method and Universal Resolver driver? Click [Driver Dev
 | did-v1 |  | [0.11](https://w3c-ccg.github.io/did-spec/) | [1.0](https://w3c-ccg.github.io/didm-veres-one/) |
 | did-ipid |  | [0.11](https://w3c-ccg.github.io/did-spec/) | [0.1](https://github.com/jonnycrunch/ipid) |
 | [did-jolo](https://github.com/jolocom/jolocom-did-driver) | 0.1 | [0.11](https://w3c-ccg.github.io/did-spec/) | [0.1](https://github.com/jolocom/jolocom-did-driver/blob/master/jolocom-did-method-specification.md) | [jolocomgmbh/jolocom-did-driver](https://hub.docker.com/r/jolocomgmbh/jolocom-did-driver) |
+| [did-hacera](https://github.com/hacera/hacera-did-driver) | 0.1 | [0.11](https://w3c-ccg.github.io/did-spec/) | (missing) | [hacera/hacera-did-driver](https://hub.docker.com/r/hacera/hacera-did-driver) |
 
 ## More Information
 

--- a/config.json
+++ b/config.json
@@ -73,6 +73,11 @@
 			"image": "jolocomgmbh/jolocom-did-driver",
 			"tag": "latest",
 			"testIdentifiers": [ "did:jolo:e76fb4b4900e43891f613066b9afca366c6d22f7d87fc9f78a91515be24dfb21" ]
-		}
+		}, {
+			"pattern": "^(did:hcr:.+)$",
+			"image": "hacera/hacera-did-driver",
+			"tag": "latest",
+			"testIdentifiers": [ "did:hcr:0f674e7e-4b49-4898-85f6-96176c1e30de" ]
+        }
 	]
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,6 +53,10 @@ services:
     image: jolocomgmbh/jolocom-did-driver:latest
     ports:
       - "8088:8080"
+  driver-did-hacera:
+    image: hacera/hacera-did-driver:latest
+    ports:
+      - "8089:8080"
   uni-resolver-web:
     image: universalresolver/uni-resolver-web:latest
     ports:

--- a/resolver/java/uni-resolver-web/src/main/webapp/WEB-INF/applicationContext.xml
+++ b/resolver/java/uni-resolver-web/src/main/webapp/WEB-INF/applicationContext.xml
@@ -18,6 +18,7 @@
 				<entry key="did:dom"><ref bean="DidDomDriver" /></entry>
 				<entry key="dns-did"><ref bean="DnsDriver" /></entry>
 				<entry key="did:jolo"><ref bean="DidJoloDriver" /></entry>
+				<entry key="did:hcr"><ref bean="DidHaceraDriver" /></entry>
 			</util:map>
 		</property>
 	</bean>
@@ -86,6 +87,11 @@
 	<bean id="DidJoloDriver" class="uniresolver.driver.http.HttpDriver">
 		<property name="resolveUri" value="http://driver-did-jolo:8080/1.0/identifiers/$1" />
 		<property name="pattern" value="^(did:jolo:.+)$" />
+	</bean>
+
+	<bean id="DidHaceraDriver" class="uniresolver.driver.http.HttpDriver">
+		<property name="resolveUri" value="http://driver-did-hacera:8080/1.0/identifiers/$1" />
+		<property name="pattern" value="^(did:hcr:.+)$" />
 	</bean>
 
 </beans>


### PR DESCRIPTION
Hello everybody,

While we should have probably done this a lot earlier (2017 was probably just about the right time, way closer to that historical RWOT session)... we would love to have the did:hcr universal driver registered as part of the other universal resolvers.

The name of the driver is did-hacera. For abbreviation and to keep it in line with the rest, we have been using the "did:hcr:" prefix.

Thank you,
HACERA, INC.