### PR TITLE
Add element did driver: did-elem v1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Are you developing a DID method and Universal Resolver driver? Click [Driver Dev
 | did-ipid |  | [0.11](https://w3c-ccg.github.io/did-spec/) | [0.1](https://github.com/jonnycrunch/ipid) |
 | [did-jolo](https://github.com/jolocom/jolocom-did-driver) | 0.1 | [0.11](https://w3c-ccg.github.io/did-spec/) | [0.1](https://github.com/jolocom/jolocom-did-driver/blob/master/jolocom-did-method-specification.md) | [jolocomgmbh/jolocom-did-driver](https://hub.docker.com/r/jolocomgmbh/jolocom-did-driver) |
 | [did-hacera](https://github.com/hacera/hacera-did-driver) | 0.1 | [0.11](https://w3c-ccg.github.io/did-spec/) | (missing) | [hacera/hacera-did-driver](https://hub.docker.com/r/hacera/hacera-did-driver) |
+| [did-elem](https://github.com/decentralized-identity/element) | 0.1 | [0.11](https://w3c-ccg.github.io/did-spec/) | (missing) | |
 
 ## More Information
 

--- a/config.json
+++ b/config.json
@@ -80,7 +80,7 @@
     }, {
 			"pattern": "^did:elem:(.+)$",
 			"url": "https://element-did.com/api/v1/sidetree/$1",
-			"testIdentifiers": [ "did:elem:y8wEF7WsB8yaSQRJFD_fbr25E8lhcv3WKfTVVAo8ywo" ]
+			"testIdentifiers": [ "did:elem:sscP2_bGvj2z6qnSV68ja-WR8WKCLTvNoRJjYSBvDZs" ]
 		}
 	]
 }

--- a/config.json
+++ b/config.json
@@ -77,6 +77,10 @@
 			"image": "hacera/hacera-did-driver",
 			"tag": "latest",
 			"testIdentifiers": [ "did:hcr:0f674e7e-4b49-4898-85f6-96176c1e30de" ]
-        }
+    }, {
+			"pattern": "^did:elem:(.+)$",
+			"url": "https://element-did.com/api/v1/sidetree/$1",
+			"testIdentifiers": [ "did:elem:y8wEF7WsB8yaSQRJFD_fbr25E8lhcv3WKfTVVAo8ywo" ]
+		}
 	]
 }

--- a/resolver/java/uni-resolver-web/src/main/webapp/WEB-INF/applicationContext.xml
+++ b/resolver/java/uni-resolver-web/src/main/webapp/WEB-INF/applicationContext.xml
@@ -19,6 +19,7 @@
 				<entry key="dns-did"><ref bean="DnsDriver" /></entry>
 				<entry key="did-jolo"><ref bean="DidJoloDriver" /></entry>
 				<entry key="did-hacera"><ref bean="DidHaceraDriver" /></entry>
+				<entry key="did-elem"><ref bean="DidElemDriver" /></entry>
 			</util:map>
 		</property>
 	</bean>
@@ -93,4 +94,8 @@
 		<property name="pattern" value="^(did:hcr:.+)$" />
 	</bean>
 
+	<bean id="DidElemDriver" class="uniresolver.driver.http.HttpDriver">
+		<property name="resolveUri" value="https://element-did.com/api/v1/sidetree/$1" />
+		<property name="pattern" value="^did:elem:(.+)$" />
+	</bean>
 </beans>

--- a/resolver/java/uni-resolver-web/src/main/webapp/WEB-INF/applicationContext.xml.docker
+++ b/resolver/java/uni-resolver-web/src/main/webapp/WEB-INF/applicationContext.xml.docker
@@ -19,6 +19,7 @@
 				<entry key="dns-did"><ref bean="DnsDriver" /></entry>
 				<entry key="did-jolo"><ref bean="DidJoloDriver" /></entry>
 				<entry key="did-hacera"><ref bean="DidHaceraDriver" /></entry>
+				<entry key="did-elem"><ref bean="DidElemDriver" /></entry>
 			</util:map>
 		</property>
 	</bean>
@@ -93,4 +94,8 @@
 		<property name="pattern" value="^(did:hcr:.+)$" />
 	</bean>
 
+	<bean id="DidElemDriver" class="uniresolver.driver.http.HttpDriver">
+		<property name="resolveUri" value="https://element-did.com/api/v1/sidetree/$1" />
+		<property name="pattern" value="^did:elem:(.+)$" />
+	</bean>
 </beans>


### PR DESCRIPTION
## This PR
Adding [element-did](https://github.com/decentralized-identity/element) to the universal resolver.

Element DID is an experimental Sidetree based DID Method implementation that uses Ethereum and IPFS

In this PR we updated the files according to the [documentation](https://github.com/decentralized-identity/universal-resolver/blob/master/docs/driver-development.md)

## Next Steps
- Submit a Docker container to replace the HTTP Proxy
- Write a DID Spec for Element DID
- Write a test to verify it works 