### PR TITLE
fix resolver build issue

### DIFF
--- a/resolver/java/README.md
+++ b/resolver/java/README.md
@@ -14,7 +14,7 @@ First, build https://github.com/decentralized-identity/did-common-java
 
 Then run:
 
-	mvn clean install -pl !examples
+	mvn clean install -pl '!examples'
 
 ## Local Resolver
 


### PR DESCRIPTION
Run `mvn clean install -pl !examples` got this error:
```text
zsh: event not found: examples
```

Run `mvn clean install -pl '!examples'` fix this.