### PR TITLE
Add Baidu Cloud DID Driver

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,4 +29,5 @@ job 1:
    - cd stack && docker build -f ./docker/Dockerfile . -t $TAG_ROOT/driver-did-stack && cd ..
    - cd dom && docker build -f ./docker/Dockerfile . -t $TAG_ROOT/driver-did-dom && cd ..
    - cd dns && docker build -f ./docker/Dockerfile . -t $TAG_ROOT/driver-did-dns && cd ..
+   - cd ccp && docker build -f ./docker/Dockerfile . -t $TAG_ROOT/driver-did-ccp && cd ..
    - cd ..

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ You should then be able to resolve identifiers locally using simple `curl` reque
 	curl -X GET http://localhost:8080/1.0/identifiers/did:neoid:priv:b4eeeb80d20bfb38b23001d0659ce0c1d96be0aa
 	curl -X GET http://localhost:8080/1.0/identifiers/did:elem:-53k-sZFvElLHIiCM-XYydGgFV8aRy_VWAeePUVuCOM
 	curl -X GET http://localhost:8080/1.0/identifiers/did:github:gjgd
-
+	curl -X GET http://localhost:8080/1.0/identifiers/did:ccp:ceNobbK6Me9F5zwyE3MKY88QZLw
 
 If this doesn't work, see [Troubleshooting](/docs/troubleshooting.md).
 
@@ -63,6 +63,7 @@ Are you developing a DID method and Universal Resolver driver? Click [Driver Dev
 | [did-elem](https://github.com/decentralized-identity/element) | 0.1 | [0.11](https://w3c-ccg.github.io/did-spec/) | (missing) | |
 | [did-seraphid](https://github.com/swisscom-blockchain/seraph-id-did-driver) | 0.1 | [0.11](https://w3c-ccg.github.io/did-spec/) | (missing) |  [swisscomblockchainag/seraph-id-did-driver](https://hub.docker.com/r/swisscomblockchainag/seraph-id-did-driver) |
 | [did-github](https://github.com/decentralized-identity/github-did) | 0.1 | [0.11](https://w3c-ccg.github.io/did-spec/) | (missing) | |
+| [did-ccp](https://github.com/decentralized-identity/universal-resolver/tree/master/drivers/ccp/) | 0.1-SNAPSHOT | [0.11](https://w3c-ccg.github.io/did-spec/) | [0.1](https://did.baidu.com/did-spec/) | [hello2mao/driver-did-ccp](https://hub.docker.com/r/hello2mao/driver-did-ccp/)
 
 ## More Information
 

--- a/config.json
+++ b/config.json
@@ -90,6 +90,11 @@
 			"image": "swisscomblockchainag/seraph-id-did-driver",
 			"tag": "latest",
 			"testIdentifiers" : [ "did:neoid:priv:b4eeeb80d20bfb38b23001d0659ce0c1d96be0aa" ]
+		}, {
+			"pattern": "^(did:ccp:.+)$",
+			"image": "hello2mao/driver-did-ccp",
+			"tag": "latest",
+			"testIdentifiers": ["did:ccp:ceNobbK6Me9F5zwyE3MKY88QZLw", "did:ccp:3CzQLF3qfFVQ1CjGVzVRZaFXrjAd"]
 		}
 	]
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,10 @@ services:
     image: swisscomblockchainag/seraph-id-did-driver:latest
     ports:
       - "8090:8080"
+  driver-did-ccp:
+    image: hello2mao/driver-did-ccp:latest
+    ports:
+      - "8091:8080"
   uni-resolver-web:
     image: universalresolver/uni-resolver-web:latest
     ports:

--- a/drivers/ccp/.gitignore
+++ b/drivers/ccp/.gitignore
@@ -1,0 +1,7 @@
+.project
+.classpath
+/.settings/
+/target
+/bin/
+.idea
+*.iml

--- a/drivers/ccp/README.md
+++ b/drivers/ccp/README.md
@@ -1,0 +1,49 @@
+![DIF Logo](https://raw.githubusercontent.com/decentralized-identity/decentralized-identity.github.io/master/images/logo-small.png)
+
+# Universal Resolver Driver: did:ccp
+
+This is a [Universal Resolver](https://github.com/decentralized-identity/universal-resolver/) driver for **did:ccp** identifiers.
+
+More info: 
+
+- [Solution Homepage](https://cloud.baidu.com/solution/digitalIdentity.html)
+- [Docs Homepage](https://did.baidu.com)
+
+## Specifications
+
+* [Decentralized Identifiers](https://w3c-ccg.github.io/did-spec/)
+* [Baidu Cloud DID Method Specification](https://did.baidu.com/did-spec/)
+
+## Example DIDs
+
+```
+did:ccp:ceNobbK6Me9F5zwyE3MKY88QZLw
+did:ccp:3CzQLF3qfFVQ1CjGVzVRZaFXrjAd
+```
+
+## Build and Run (Docker)
+
+```
+docker build -f ./docker/Dockerfile . -t hello2mao/driver-did-ccp
+docker run -p 8080:8080 hello2mao/driver-did-ccp
+curl -X GET http://localhost:8080/1.0/identifiers/did:ccp:ceNobbK6Me9F5zwyE3MKY88QZLw
+```
+
+## Build (native Java)
+
+ 1. First, build https://github.com/decentralized-identity/universal-resolver/tree/master/resolver/java
+
+Then run:
+
+	mvn clean install
+
+## Driver Metadata
+
+The driver returns the following metadata in addition to a DID document:
+
+* `version`: The DID version.
+* `proof`: Some proof info about the DID document.
+* `created`: The DID create time.
+* `updated`: The DID document last update time.
+
+

--- a/drivers/ccp/README.md
+++ b/drivers/ccp/README.md
@@ -46,4 +46,6 @@ The driver returns the following metadata in addition to a DID document:
 * `created`: The DID create time.
 * `updated`: The DID document last update time.
 
+## Maintainer
 
+- Hongbin Mao [@hello2mao](https://github.com/hello2mao)

--- a/drivers/ccp/docker/Dockerfile
+++ b/drivers/ccp/docker/Dockerfile
@@ -1,0 +1,16 @@
+# Dockerfile for hello2mao/driver-did-ccp
+
+FROM universalresolver/base-ubuntu
+MAINTAINER Markus Sabadello <markus@danubetech.com>
+
+# build driver-did-ccp
+
+ADD . /opt/driver-did-ccp
+RUN cd /opt/driver-did-ccp && mvn clean install package -N -DskipTests
+
+# done
+
+EXPOSE 8080
+
+RUN chmod a+rx /opt/driver-did-ccp/docker/run-driver-did-ccp.sh
+CMD "/opt/driver-did-ccp/docker/run-driver-did-ccp.sh"

--- a/drivers/ccp/docker/run-driver-did-ccp.sh
+++ b/drivers/ccp/docker/run-driver-did-ccp.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+cd /opt/driver-did-ccp/
+mvn jetty:run -P war

--- a/drivers/ccp/pom.xml
+++ b/drivers/ccp/pom.xml
@@ -1,0 +1,111 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+	<artifactId>uni-resolver-driver-did-ccp</artifactId>
+	<packaging>${packaging.type}</packaging>
+	<name>uni-resolver-driver-did-ccp</name>
+
+	<parent>
+		<groupId>decentralized-identity</groupId>
+		<artifactId>uni-resolver</artifactId>
+		<version>0.1-SNAPSHOT</version>
+	</parent>
+
+	<profiles>
+
+		<profile>
+
+			<id>default</id>
+			<activation><activeByDefault>true</activeByDefault></activation>
+			<properties><packaging.type>jar</packaging.type></properties>
+
+		</profile>
+
+		<profile>
+
+			<id>war</id>
+			<properties><packaging.type>war</packaging.type></properties>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-war-plugin</artifactId>
+						<version>3.2.2</version>
+					</plugin>
+					<plugin>
+						<groupId>org.eclipse.jetty</groupId>
+						<artifactId>jetty-maven-plugin</artifactId>
+						<version>9.4.18.v20190429</version>
+						<configuration>
+							<jettyConfig>
+								${basedir}/src/test/resources/jetty.xml
+							</jettyConfig>
+							<jettyEnvXml>
+								${basedir}/src/test/resources/jetty-env.xml
+							</jettyEnvXml>
+							<contextPath>/</contextPath>
+							<useTestClasspath>true</useTestClasspath>
+							<systemProperties>
+								<systemProperty>
+									<name>jetty.port</name>
+									<value>8080</value>
+								</systemProperty>
+								<systemProperty>
+									<name>slf4j</name>
+									<value>true</value>
+								</systemProperty>
+								<systemProperty>
+									<name>log4j.configuration</name>
+									<value>file:${basedir}/src/test/resources/log4j.properties</value>
+								</systemProperty>
+							</systemProperties>
+							<webApp>
+								<webInfIncludeJarPattern>^$</webInfIncludeJarPattern>
+								<containerIncludeJarPattern>^$</containerIncludeJarPattern>
+							</webApp>
+						</configuration>
+						<dependencies>
+							<dependency>
+								<groupId>org.slf4j</groupId>
+								<artifactId>slf4j-api</artifactId>
+								<version>1.7.25</version>
+								<scope>compile</scope>
+							</dependency>
+							<dependency>
+								<groupId>org.slf4j</groupId>
+								<artifactId>jcl-over-slf4j</artifactId>
+								<version>1.7.25</version>
+								<scope>compile</scope>
+							</dependency>
+							<dependency>
+								<groupId>org.slf4j</groupId>
+								<artifactId>slf4j-log4j12</artifactId>
+								<version>1.7.25</version>
+								<scope>compile</scope>
+							</dependency>
+						</dependencies>
+					</plugin>
+				</plugins>
+			</build>
+
+		</profile>
+
+	</profiles>
+
+	<dependencies>
+		<dependency>
+			<groupId>decentralized-identity</groupId>
+			<artifactId>uni-resolver-driver</artifactId>
+			<version>0.1-SNAPSHOT</version>
+			<scope>compile</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.json</groupId>
+			<artifactId>json</artifactId>
+			<version>20171018</version>
+			<scope>compile</scope>
+		</dependency>
+	</dependencies>
+
+</project>

--- a/drivers/ccp/src/main/java/uniresolver/driver/did/ccp/DidCcpDriver.java
+++ b/drivers/ccp/src/main/java/uniresolver/driver/did/ccp/DidCcpDriver.java
@@ -1,0 +1,174 @@
+package uniresolver.driver.did.ccp;
+
+import did.Authentication;
+import did.DIDDocument;
+import did.PublicKey;
+import did.Service;
+import org.apache.http.HttpEntity;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.LaxRedirectStrategy;
+import org.apache.http.util.EntityUtils;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.json.JSONObject;
+import uniresolver.ResolutionException;
+import uniresolver.driver.Driver;
+import uniresolver.result.ResolveResult;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class DidCcpDriver implements Driver {
+
+	private static Logger log = LoggerFactory.getLogger(DidCcpDriver.class);
+
+	public static final Pattern DID_CCP_PATTERN = Pattern.compile("^did:ccp:([123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{25,34})$");
+
+	public static final String[] DIDDOCUMENT_PUBLICKEY_TYPES = new String[] { "Secp256k1" };
+
+	public static final String[] DIDDOCUMENT_AUTHENTICATION_TYPES = new String[] { "Secp256k1" };
+
+	public static final String DEFAULT_CCP_URL = "https://did.baidu.com";
+
+	public static final HttpClient DEFAULT_HTTP_CLIENT = HttpClientBuilder.create().setRedirectStrategy(new LaxRedirectStrategy()).build();
+
+	private String ccpUrl = DEFAULT_CCP_URL;
+
+	private HttpClient httpClient = DEFAULT_HTTP_CLIENT;
+
+	public DidCcpDriver() {
+	}
+
+	@Override
+	public ResolveResult resolve(String identifier) throws ResolutionException {
+		// match
+		Matcher matcher = DID_CCP_PATTERN.matcher(identifier);
+		if(!matcher.matches()) {
+			return null;
+		}
+
+		// fetch data from CCP
+		String resolveUrl = this.getCCPUrl() + "/v1/did/resolve/" + identifier;
+		HttpGet httpGet = new HttpGet(resolveUrl);
+
+		// find the DDO
+		JSONObject didDocumentDO;
+		try {
+			CloseableHttpResponse httpResponse = (CloseableHttpResponse) this.getHttpClient().execute(httpGet);
+			if(httpResponse.getStatusLine().getStatusCode() != 200) {
+				throw new ResolutionException("Cannot retrieve DDO for `" + identifier + "` from `" + this.getCCPUrl() + ": " + httpResponse.getStatusLine());
+			}
+
+			// extract payload
+			HttpEntity httpEntity = httpResponse.getEntity();
+			String entityString = EntityUtils.toString(httpEntity);
+			EntityUtils.consume(httpEntity);
+
+			// get DDO
+			JSONObject jo = new JSONObject(entityString);
+			didDocumentDO = jo.getJSONObject("content").getJSONObject("didDocument");
+		} catch (IOException ex) {
+			throw new ResolutionException("Cannot retrieve DDO info for `" + identifier + "` from `" + this.getCCPUrl() + "`: " + ex.getMessage(), ex);
+		} catch (JSONException jex) {
+			throw new ResolutionException("Cannot parse JSON response from `" + this.getCCPUrl() + "`: " + jex.getMessage(), jex);
+		}
+
+		// DDO id
+
+		// DDO publicKeys
+		List<PublicKey> publicKeys = new ArrayList<>();
+		// index 0 is auth key
+		JSONObject firstKeyJO = didDocumentDO.getJSONArray("publicKey").getJSONObject(0);
+		publicKeys.add(PublicKey.build(
+				firstKeyJO.getString("id"),
+				DIDDOCUMENT_PUBLICKEY_TYPES,
+				null,
+				null,
+				firstKeyJO.getString("publicKeyHex"),
+				null));
+		// index 1 is recovery key
+		JSONObject secondKeyJO = didDocumentDO.getJSONArray("publicKey").getJSONObject(1);
+		publicKeys.add(PublicKey.build(
+				secondKeyJO.getString("id"),
+				DIDDOCUMENT_PUBLICKEY_TYPES,
+				null,
+				null,
+				secondKeyJO.getString("publicKeyHex"),
+				null));
+
+		// DDO Authentications
+		List<Authentication> authentications = new ArrayList<>();
+		authentications.add(Authentication.build(
+				null,
+				DIDDOCUMENT_AUTHENTICATION_TYPES,
+				firstKeyJO.getString("id")));
+
+		// DDO services
+		List<Service> services = new ArrayList<>();
+		JSONArray serviceJA = didDocumentDO.getJSONArray("service");
+		for (int i = 0; i < serviceJA.length(); i++) {
+			JSONObject service = serviceJA.getJSONObject(i);
+			services.add(Service.build(service.getString("type"), service.getString("serviceEndpoint")));
+		}
+
+		// create DDO
+		DIDDocument didDocument = DIDDocument.build(identifier, publicKeys, authentications, services);
+
+		// create Method METADATA
+		Map<String, Object> methodMetadata = new LinkedHashMap<>();
+		methodMetadata.put("version", didDocumentDO.getInt("version"));
+		methodMetadata.put("proof", didDocumentDO.getJSONObject("proof").toMap());
+		methodMetadata.put("created", didDocumentDO.getString("created"));
+		methodMetadata.put("updated", didDocumentDO.getString("updated"));
+
+		// create RESOLVE RESULT
+		ResolveResult resolveResult = ResolveResult.build(didDocument, null, methodMetadata);
+
+		// done
+		return resolveResult;
+	}
+
+	@Override
+	public Map<String, Object> properties() {
+
+		Map<String, Object> properties = new HashMap<>();
+		properties.put("ccpUrl", this.getCCPUrl());
+
+		return properties;
+	}
+
+	/*
+	 * Getters and setters
+	 */
+
+	public String getCCPUrl() {
+
+		return this.ccpUrl;
+	}
+
+	public void setCCPUrl(String ccpUrl) {
+		this.ccpUrl = ccpUrl;
+	}
+
+	public HttpClient getHttpClient() {
+
+		return this.httpClient;
+	}
+
+	public void setHttpClient(HttpClient httpClient) {
+
+		this.httpClient = httpClient;
+	}
+}

--- a/drivers/ccp/src/main/java/uniresolver/driver/did/ccp/DidCcpDriver.java
+++ b/drivers/ccp/src/main/java/uniresolver/driver/did/ccp/DidCcpDriver.java
@@ -86,6 +86,7 @@ public class DidCcpDriver implements Driver {
 		}
 
 		// DDO id
+		String id = identifier;
 
 		// DDO publicKeys
 		List<PublicKey> publicKeys = new ArrayList<>();
@@ -124,7 +125,7 @@ public class DidCcpDriver implements Driver {
 		}
 
 		// create DDO
-		DIDDocument didDocument = DIDDocument.build(identifier, publicKeys, authentications, services);
+		DIDDocument didDocument = DIDDocument.build(id, publicKeys, authentications, services);
 
 		// create Method METADATA
 		Map<String, Object> methodMetadata = new LinkedHashMap<>();

--- a/drivers/ccp/src/main/webapp/WEB-INF/web.xml
+++ b/drivers/ccp/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns="http://java.sun.com/xml/ns/javaee" xmlns:web="http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
+	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
+	id="WebApp_ID" version="2.5" metadata-complete="true">
+
+	<display-name>uni-resolver-driver-did-ccp</display-name>
+
+	<!-- SERVLET -->
+
+	<servlet>
+		<display-name>InitServlet</display-name>
+		<servlet-name>InitServlet</servlet-name>
+		<servlet-class>uniresolver.driver.servlet.InitServlet</servlet-class>
+		<init-param>
+			<param-name>Driver</param-name>
+			<param-value>uniresolver.driver.did.ccp.DidCcpDriver</param-value>
+		</init-param>
+		<load-on-startup>1</load-on-startup>
+	</servlet>
+
+	<servlet>
+		<display-name>ResolveServlet</display-name>
+		<servlet-name>ResolveServlet</servlet-name>
+		<servlet-class>uniresolver.driver.servlet.ResolveServlet</servlet-class>
+	</servlet>
+	<servlet>
+		<display-name>PropertiesServlet</display-name>
+		<servlet-name>PropertiesServlet</servlet-name>
+		<servlet-class>uniresolver.driver.servlet.PropertiesServlet</servlet-class>
+	</servlet>
+	<servlet-mapping>
+		<servlet-name>ResolveServlet</servlet-name>
+		<url-pattern>/1.0/identifiers/*</url-pattern>
+	</servlet-mapping>
+	<servlet-mapping>
+		<servlet-name>PropertiesServlet</servlet-name>
+		<url-pattern>/1.0/properties</url-pattern>
+		<url-pattern>/1.0/properties/*</url-pattern>
+	</servlet-mapping>
+
+</web-app>

--- a/drivers/ccp/src/test/resources/jetty-env.xml
+++ b/drivers/ccp/src/test/resources/jetty-env.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure.dtd">
+<Configure id="JettyWebAppContext" class="org.eclipse.jetty.maven.plugin.JettyWebAppContext">
+	<Call name="setAttribute">
+		<Arg>org.eclipse.jetty.server.webapp.WebInfIncludeJarPattern</Arg>
+		<Arg>^$</Arg>
+	</Call>
+</Configure>

--- a/drivers/ccp/src/test/resources/jetty.xml
+++ b/drivers/ccp/src/test/resources/jetty.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure.dtd">
+<Configure id="JettyServer" class="org.eclipse.jetty.server.Server">
+</Configure>

--- a/drivers/ccp/src/test/resources/log4j.properties
+++ b/drivers/ccp/src/test/resources/log4j.properties
@@ -1,0 +1,11 @@
+log4j.rootLogger=DEBUG, STDOUT
+
+log4j.appender.STDOUT=org.apache.log4j.ConsoleAppender
+log4j.appender.STDOUT.layout=org.apache.log4j.PatternLayout
+log4j.appender.STDOUT.layout.ConversionPattern=%d{HH:mm:ss,SSS} - %5p [%c] - %m%n
+
+log4j.logger.org.apache=INFO, STDOUT
+log4j.logger.org.eclipse=INFO, STDOUT
+log4j.logger.org.mortbay=INFO, STDOUT
+log4j.logger.org.springframework=INFO, STDOUT
+log4j.logger.uniresolver=DEBUG, STDOUT

--- a/resolver/java/uni-resolver-web/config.json
+++ b/resolver/java/uni-resolver-web/config.json
@@ -96,6 +96,11 @@
 			"image": "swisscomblockchainag/seraph-id-did-driver",
 			"tag": "latest",
 			"testIdentifiers" : [ "did:neoid:priv:b4eeeb80d20bfb38b23001d0659ce0c1d96be0aa" ]
+		}, {
+			"pattern": "^(did:ccp:.+)$",
+			"image": "hello2mao/driver-did-ccp",
+			"tag": "latest",
+			"testIdentifiers": ["did:ccp:ceNobbK6Me9F5zwyE3MKY88QZLw", "did:ccp:3CzQLF3qfFVQ1CjGVzVRZaFXrjAd"]
 		}
 	]
 }


### PR DESCRIPTION
This PR adds [Baidu](http://ir.baidu.com/) Cloud DID Driver: `did:ccp:`

[Cloud DID](https://did.baidu.com/) is the Baidu implementation of DID(Decentralized ID). It relies on the [W3C standards](https://w3c-ccg.github.io/did-primer/) providing **DID** and **Verifiable Credential Claim**.

More details:
- [Solution Homepage](https://cloud.baidu.com/solution/digitalIdentity.html)
- [Docs Homepage](https://did.baidu.com)

Here are some DID resolving examples for the `did:ccp:` method:
```shell
curl -X GET http://localhost:8080/1.0/identifiers/did:ccp:ceNobbK6Me9F5zwyE3MKY88QZLw
curl -X GET http://localhost:8080/1.0/identifiers/did:ccp:3CzQLF3qfFVQ1CjGVzVRZaFXrjAd
```

Related PRs:
-  PR on the DID method registry: https://github.com/w3c-ccg/did-method-registry/pull/64