### PR TITLE
Add ONT ID driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ You should then be able to resolve identifiers locally using simple `curl` reque
 	curl -X GET http://localhost:8080/1.0/identifiers/did:github:gjgd
 	curl -X GET http://localhost:8080/1.0/identifiers/did:ccp:ceNobbK6Me9F5zwyE3MKY88QZLw
 	curl -X GET http://localhost:8080/1.0/identifiers/did:work:2UUHQCd4psvkPLZGnWY33L
+	curl -X GET http://localhost:8080/1.0/identifiers/did:ont:AN5g6gz9EoQ3sCNu7514GEghZurrktCMiH
 
 If this doesn't work, see [Troubleshooting](/docs/troubleshooting.md).
 
@@ -66,6 +67,7 @@ Are you developing a DID method and Universal Resolver driver? Click [Driver Dev
 | [did-github](https://github.com/decentralized-identity/github-did) | 0.1 | [0.11](https://w3c-ccg.github.io/did-spec/) | (missing) | |
 | [did-ccp](https://github.com/decentralized-identity/universal-resolver/tree/master/drivers/ccp/) | 0.1-SNAPSHOT | [0.11](https://w3c-ccg.github.io/did-spec/) | [0.1](https://did.baidu.com/did-spec/) | [hello2mao/driver-did-ccp](https://hub.docker.com/r/hello2mao/driver-did-ccp/)
 | [did-work](https://github.com/decentralized-identity/universal-resolver/tree/master/drivers/work/) | 0.1  | [0.13](https://w3c-ccg.github.io/did-spec/) | [1.0](https://workday.github.io/work-did-method-spec/) | [didwork/work-did-driver](https://hub.docker.com/r/didwork/work-did-driver)|
+| [did-ont](https://github.com/ontio/ontid-driver) | 0.1 | [1.0](https://w3c.github.io/did-core/) | [1.0](https://github.com/ontio/ontology-DID/blob/master/docs/en/DID-ONT-method.md) |  [ontio/ontid-driver](https://hub.docker.com/r/ontio/ontid-driver) | 
 
 ## More Information
 

--- a/config.json
+++ b/config.json
@@ -82,6 +82,11 @@
 			"tag": "latest",
 			"testIdentifiers" : [ "did:work:2UUHQCd4psvkPLZGnWY33L" ]
 		}, {
+			"pattern": "^(did:ont:.+)$",
+			"image": "ontio/ontid-driver",
+			"tag": "latest",
+			"testIdentifiers": [ "did:ont:AN5g6gz9EoQ3sCNu7514GEghZurrktCMiH" ]
+		}, {
 			"pattern": "^(did:key:.+)$",
 			"url": "https://did-key.web.app/api/dids/$1",
 			"testIdentifiers": [ "did:key:z6MksQ35B5bwZDQq4QKuhQW2Sv6dcqwg4PqcSFf67pdgrtjB" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,6 +65,10 @@ services:
       uniresolver_driver_did_work_domain: ${uniresolver_driver_did_work_domain}
     ports:
       - "8092:8080"
+  ont-did-driver:
+    image: ontio/ontid-driver:latest
+    ports:
+      - "8093:8080"
   uni-resolver-web:
     image: universalresolver/uni-resolver-web:latest
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,7 +65,7 @@ services:
       uniresolver_driver_did_work_domain: ${uniresolver_driver_did_work_domain}
     ports:
       - "8092:8080"
-  ont-did-driver:
+  ontid-driver:
     image: ontio/ontid-driver:latest
     ports:
       - "8093:8080"


### PR DESCRIPTION
Request to add the ONT ID Driver to the universal resolver.

The DID method spec can be found here https://github.com/ontio/ontology-DID/blob/master/docs/en/DID-ONT-method.md.

ONT ID has also been added to the DID Method Registry: https://w3c-ccg.github.io/did-method-registry/#the-registry.