### PR TITLE
Develop evan did uni resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ You should then be able to resolve identifiers locally using simple `curl` reque
 	curl -X GET http://localhost:8080/1.0/identifiers/did:work:2UUHQCd4psvkPLZGnWY33L
 	curl -X GET http://localhost:8080/1.0/identifiers/did:ont:AN5g6gz9EoQ3sCNu7514GEghZurrktCMiH
 	curl -X GET http://localhost:8080/1.0/identifiers/did:kilt:5CDct4QDpQYfAVDrskNuiEdXyiE38oPfTHEJ65ZLSpz9WasE
+	curl -X GET http://localhost:8080/1.0/identifiers/did:evan:testcore:0x126E901F6F408f5E260d95c62E7c73D9B60fd734
 
 If this doesn't work, see [Troubleshooting](/docs/troubleshooting.md).
 
@@ -63,6 +64,7 @@ Are you developing a DID method and Universal Resolver driver? Click [Driver Dev
 | [did-work](https://github.com/decentralized-identity/uni-resolver-driver-did-work/) | 0.1  | [1.0 WD](https://w3c.github.io/did-core/) | [1.0](https://workday.github.io/work-did-method-spec/) | [didwork/work-did-driver](https://hub.docker.com/r/didwork/work-did-driver)|
 | [did-ont](https://github.com/ontio/ontid-driver) | 0.1 | [1.0 WD](https://w3c.github.io/did-core/) | [1.0](https://github.com/ontio/ontology-DID/blob/master/docs/en/DID-ONT-method.md) |  [ontio/ontid-driver](https://hub.docker.com/r/ontio/ontid-driver) |
 | [did-kilt](https://github.com/KILTprotocol/kilt-did-driver) | 0.1 | [1.0 WD](https://w3c.github.io/did-core/) | [1.0](https://github.com/KILTprotocol/kilt-did-driver/blob/master/DID%20Method%20Specification.md) | [kiltprotocol/kilt-did-driver](https://hub.docker.com/r/kiltprotocol/kilt-did-driver)|
+| [did-evan](https://github.com/evannetwork/did-driver) | 0.1 | [1.0 WD](https://w3c.github.io/did-core/) | [0.9](https://github.com/evannetwork/evan.network-DID-method-specification/blob/master/evan_did_method_spec.md) | NA |
 
 ## More Information
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Are you developing a DID method and Universal Resolver driver? Click [Driver Dev
 | [did-work](https://github.com/decentralized-identity/uni-resolver-driver-did-work/) | 0.1  | [1.0 WD](https://w3c.github.io/did-core/) | [1.0](https://workday.github.io/work-did-method-spec/) | [didwork/work-did-driver](https://hub.docker.com/r/didwork/work-did-driver)|
 | [did-ont](https://github.com/ontio/ontid-driver) | 0.1 | [1.0 WD](https://w3c.github.io/did-core/) | [1.0](https://github.com/ontio/ontology-DID/blob/master/docs/en/DID-ONT-method.md) |  [ontio/ontid-driver](https://hub.docker.com/r/ontio/ontid-driver) |
 | [did-kilt](https://github.com/KILTprotocol/kilt-did-driver) | 0.1 | [1.0 WD](https://w3c.github.io/did-core/) | [1.0](https://github.com/KILTprotocol/kilt-did-driver/blob/master/DID%20Method%20Specification.md) | [kiltprotocol/kilt-did-driver](https://hub.docker.com/r/kiltprotocol/kilt-did-driver)|
-| [did-evan](https://github.com/evannetwork/did-driver) | 0.1 | [1.0 WD](https://w3c.github.io/did-core/) | [0.9](https://github.com/evannetwork/evan.network-DID-method-specification/blob/master/evan_did_method_spec.md) | NA |
+| [did-evan](https://github.com/evannetwork/did-driver) | 0.1 | [1.0 WD](https://w3c.github.io/did-core/) | [0.9](https://github.com/evannetwork/evan.network-DID-method-specification/blob/master/evan_did_method_spec.md) | [evannetwork/evan-did-driver](https://hub.docker.com/r/evannetwork/evan-did-driver) |
 
 ## More Information
 

--- a/config.json
+++ b/config.json
@@ -95,6 +95,11 @@
 			"image": "kiltprotocol/kilt-did-driver",
 			"tag": "latest",
 			"testIdentifiers" : [ "did:kilt:5CDct4QDpQYfAVDrskNuiEdXyiE38oPfTHEJ65ZLSpz9WasE" ]
+		}, {
+			"pattern": "^(did:evan:.+)$",
+			"image": "evannetwork/evan-did-driver",
+			"tag": "latest",
+			"testIdentifiers": [ "did:evan:testcore:0x126E901F6F408f5E260d95c62E7c73D9B60fd734" ]
 		}
 	]
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,6 +75,10 @@ services:
       uniresolver_driver_kilt_did_node: ${uniresolver_driver_kilt_did_node}
     ports:
       - "8094:8080"
+  evan-did-driver:
+    image: evannetwork/evan-did-driver:latest
+    ports:
+      - "8095:8080"      
   uni-resolver-web:
     image: universalresolver/uni-resolver-web:latest
     ports:


### PR DESCRIPTION
Request to add the [evan.network](https://evan.network/de/) did to universal resolver.

The DID method specification can be found here:
https://github.com/evannetwork/evan.network-DID-method-specification/blob/master/evan_did_method_spec.md

The evan.network DID method specification is under review for being added to w3c. The pull request can be found here: 
https://github.com/w3c-ccg/did-method-registry/pulls

Thanks for reviewing.