### PR TITLE
fix: updated kilt example and driver version

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ You should then be able to resolve identifiers locally using simple `curl` reque
 	curl -X GET http://localhost:8080/1.0/identifiers/did:ccp:ceNobbK6Me9F5zwyE3MKY88QZLw
 	curl -X GET http://localhost:8080/1.0/identifiers/did:work:2UUHQCd4psvkPLZGnWY33L
 	curl -X GET http://localhost:8080/1.0/identifiers/did:ont:AN5g6gz9EoQ3sCNu7514GEghZurrktCMiH
-	curl -X GET http://localhost:8080/1.0/identifiers/did:kilt:5CDct4QDpQYfAVDrskNuiEdXyiE38oPfTHEJ65ZLSpz9WasE
+	curl -X GET http://localhost:8080/1.0/identifiers/did:kilt:5GFs8gCumJcZDDWof5ETFqDFEsNwCsVJUj2bX7y4xBLxN5qT
 	curl -X GET http://localhost:8080/1.0/identifiers/did:evan:testcore:0x126E901F6F408f5E260d95c62E7c73D9B60fd734
 
 If this doesn't work, see [Troubleshooting](/docs/troubleshooting.md).
@@ -63,7 +63,7 @@ Are you developing a DID method and Universal Resolver driver? Click [Driver Dev
 | [did-ccp](https://github.com/decentralized-identity/uni-resolver-driver-did-ccp/) | 0.1-SNAPSHOT | [1.0 WD](https://w3c.github.io/did-core/) | [0.1](https://did.baidu.com/did-spec/) | [hello2mao/driver-did-ccp](https://hub.docker.com/r/hello2mao/driver-did-ccp/)
 | [did-work](https://github.com/decentralized-identity/uni-resolver-driver-did-work/) | 0.1  | [1.0 WD](https://w3c.github.io/did-core/) | [1.0](https://workday.github.io/work-did-method-spec/) | [didwork/work-did-driver](https://hub.docker.com/r/didwork/work-did-driver)|
 | [did-ont](https://github.com/ontio/ontid-driver) | 0.1 | [1.0 WD](https://w3c.github.io/did-core/) | [1.0](https://github.com/ontio/ontology-DID/blob/master/docs/en/DID-ONT-method.md) |  [ontio/ontid-driver](https://hub.docker.com/r/ontio/ontid-driver) |
-| [did-kilt](https://github.com/KILTprotocol/kilt-did-driver) | 0.1 | [1.0 WD](https://w3c.github.io/did-core/) | [1.0](https://github.com/KILTprotocol/kilt-did-driver/blob/master/DID%20Method%20Specification.md) | [kiltprotocol/kilt-did-driver](https://hub.docker.com/r/kiltprotocol/kilt-did-driver)|
+| [did-kilt](https://github.com/KILTprotocol/kilt-did-driver) | 1.0.1 | [1.0 WD](https://w3c.github.io/did-core/) | [1.0](https://github.com/KILTprotocol/kilt-did-driver/blob/master/DID%20Method%20Specification.md) | [kiltprotocol/kilt-did-driver](https://hub.docker.com/r/kiltprotocol/kilt-did-driver)|
 | [did-evan](https://github.com/evannetwork/did-driver) | 0.1 | [1.0 WD](https://w3c.github.io/did-core/) | [0.9](https://github.com/evannetwork/evan.network-DID-method-specification/blob/master/evan_did_method_spec.md) | [evannetwork/evan-did-driver](https://hub.docker.com/r/evannetwork/evan-did-driver) |
 
 ## More Information

--- a/config.json
+++ b/config.json
@@ -93,8 +93,8 @@
 		}, {
 			"pattern": "^(did:kilt:.+)$",
 			"image": "kiltprotocol/kilt-did-driver",
-			"tag": "latest",
-			"testIdentifiers" : [ "did:kilt:5CDct4QDpQYfAVDrskNuiEdXyiE38oPfTHEJ65ZLSpz9WasE" ]
+			"tag": "1.0.1",
+			"testIdentifiers" : [ "did:kilt:5GFs8gCumJcZDDWof5ETFqDFEsNwCsVJUj2bX7y4xBLxN5qT" ]
 		}, {
 			"pattern": "^(did:evan:.+)$",
 			"image": "evannetwork/evan-did-driver",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,7 +70,7 @@ services:
     ports:
       - "8093:8080"
   kilt-did-driver:
-    image: kiltprotocol/kilt-did-driver:latest
+    image: kiltprotocol/kilt-did-driver:1.0.1
     environment:
       uniresolver_driver_kilt_did_node: ${uniresolver_driver_kilt_did_node}
     ports:


### PR DESCRIPTION
Hi there,

We've made a new release on our chain and SDK, which require an update of our DID driver.

**Done in this PR:**
* Updated our driver version to 1.0.1;
* Updated our `did:kilt:` example. 

**Tested:**
Tested locally as documented on the [Universal Resolver repo](https://github.com/KILTprotocol/universal-resolver/blob/master/docs/driver-development.md).
`curl -X GET http://localhost:8080/1.0/identifiers/did:kilt:5GFs8gCumJcZDDWof5ETFqDFEsNwCsVJUj2bX7y4xBLxN5q` returned the expected DID Document.

Thanks!