### PR TITLE
Add Factom DID driver to universal resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ You should then be able to resolve identifiers locally using simple `curl` reque
 	curl -X GET http://localhost:8080/1.0/identifiers/did:kilt:5GFs8gCumJcZDDWof5ETFqDFEsNwCsVJUj2bX7y4xBLxN5qT
 	curl -X GET http://localhost:8080/1.0/identifiers/did:evan:testcore:0x126E901F6F408f5E260d95c62E7c73D9B60fd734
 	curl -X GET http://localhost:8080/1.0/identifiers/did:echo:1.1.25.0
+	curl -X GET http://localhost:8080/1.0/identifiers/did:factom:testnet:6aa7d4afe4932885b5b6e93accb5f4f6c14bd1827733e05e3324ae392c0b2764
 
 If this doesn't work, see [Troubleshooting](/docs/troubleshooting.md).
 
@@ -72,6 +73,7 @@ Are you developing a DID method and Universal Resolver driver? Click [Driver Dev
 | [did-kilt](https://github.com/KILTprotocol/kilt-did-driver) | 1.0.1 | [1.0 WD](https://w3c.github.io/did-core/) | [1.0](https://github.com/KILTprotocol/kilt-did-driver/blob/master/DID%20Method%20Specification.md) | [kiltprotocol/kilt-did-driver](https://hub.docker.com/r/kiltprotocol/kilt-did-driver)|
 | [did-evan](https://github.com/evannetwork/did-driver) | 0.1 | [1.0 WD](https://w3c.github.io/did-core/) | [0.9](https://github.com/evannetwork/evan.network-DID-method-specification/blob/master/evan_did_method_spec.md) | [evannetwork/evan-did-driver](https://hub.docker.com/r/evannetwork/evan-did-driver) |
 | [did-echo](https://github.com/echoprotocol/uni-resolver-driver-did-echo) | 0.0.1 | [1.0 WD](https://w3c.github.io/did-core/) | [1.0](https://github.com/echoprotocol/uni-resolver-driver-did-echo/blob/master/echo_did_specifications.md) | [echoprotocol/uni-resolver-driver-did-echo](https://hub.docker.com/r/echoprotocol/uni-resolver-driver-did-echo) |
+| [did-factom](https://github.com/Sphereon-Opensource/driver-did-factom) | 0.1-SNAPSHOT | [1.0 WD](https://w3c.github.io/did-core/) | [1.0](https://github.com/bi-foundation/FIS/blob/feature/DID/FIS/DID.md) | [sphereon/driver-did-factom](https://hub.docker.com/r/sphereon/driver-did-factom) |
 
 ## More Information
 

--- a/config.json
+++ b/config.json
@@ -117,6 +117,12 @@
 			"image": "echoprotocol/uni-resolver-driver-did-echo",
 			"tag": "latest",
 			"testIdentifiers": [ "did:echo:1.1.25.0" ]
+		}, {
+			"pattern": "^(did:factom:.+)$",
+			"image": "sphereon/driver-did-factom",
+			"tag": "latest",
+			"imageProperties": "true",
+			"testIdentifiers": [ "did:factom:testnet:6aa7d4afe4932885b5b6e93accb5f4f6c14bd1827733e05e3324ae392c0b2764" ]
 		}
 	]
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,6 +87,10 @@ services:
       uniresolver_driver_did_echo_devnet_rpc_url: ${uniresolver_driver_did_echo_devnet_rpc_url}
     ports:
       - "8096:8080"
+  driver-did-factom:
+    image: sphereon/driver-did-factom:latest
+    ports:
+      - "8097:8080"
   uni-resolver-web:
     image: universalresolver/uni-resolver-web:latest
     ports:


### PR DESCRIPTION
With this PR I would like to add the Factom DID driver support to the universal resolver

Driver Github: https://github.com/Sphereon-Opensource/driver-did-factom
Factom DID spec: https://github.com/bi-foundation/FIS/blob/feature/DID/FIS/DID.md