### PR TITLE
Add Teleinfo DID Driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ You should then be able to resolve identifiers locally using simple `curl` reque
 	curl -X GET http://localhost:8080/1.0/identifiers/did:mpg:7PGGnRdvKKFftSXU3Jw75Vk5npfg
 	curl -X GET http://localhost:8080/1.0/identifiers/did:trust:cert.EiBJ6qjVXgJ-A8xnaUiu4rtLDgeobQYgRWjMV49aCak4HQ
 	curl -X GET http://localhost:8080/1.0/identifiers/did:io:0x476c81C27036D05cB5ebfe30ae58C23351a61C4A
+	curl -X GET http://localhost:8080/1.0/identifiers/did:bid:6cc796b8d6e2fbebc9b3cf9e
 
 If this doesn't work, see [Troubleshooting](/docs/troubleshooting.md).
 
@@ -85,6 +86,8 @@ Are you developing a DID method and Universal Resolver driver? Click [Driver Dev
 | [did-sirius](https://gitlab.com/proximax-enterprise/siriusid/tsjs-did-sirius-id-driver) | 0.0.1 | [1.0 WD](https://w3c.github.io/did-core/) | [0.2](https://gitlab.com/proximax-enterprise/siriusid/sirius-id-specs/-/blob/master/docs/did-method-spec.md) | [proximax-enterprise/tsjs-did-sirius-id-driver](https://hub.docker.com/r/proximax/tsjs-did-sirius-id-driver)
 | [did-trust](https://github.com/bjwswang/uni-resolver-driver-did-trust) | 0.1 | [1.0 WD](https://w3c.github.io/did-core/) | [0.1](http://did.360.cn/doc/) | [bjwswang/driver-did-trust](https://hub.docker.com/repository/docker/bjwswang/driver-did-trust)
 | [did-io](https://github.com/iotexproject/uni-resolver-driver-did-io) | 0.1.0 | [1.0 WD](https://w3c.github.io/did-core/) | (missing) | [iotex/uni-resolver-driver-did-io](iotex/uni-resolver-driver-did-io:latest)
+| [did-bid](https://github.com/teleinfo-bif/bid-resolver) | 1.0.0 | [1.0 WD](https://w3c.github.io/did-core/) | [1.0.1](https://github.com/teleinfo-bif/bid/tree/master/doc/en) | [teleinfo/driver-did-bid](https://hub.docker.com/repository/docker/teleinfo/driver-did-bid)
+
 
 ## More Information
 

--- a/config.json
+++ b/config.json
@@ -163,6 +163,12 @@
 			"image": "iotex/uni-resolver-driver-did-io",
 			"tag": "latest",
 			"testIdentifiers": [ "did:io:0x476c81C27036D05cB5ebfe30ae58C23351a61C4A" ]
+		},{
+			"pattern": "^(did:bid:)([0-9a-f]{24})",
+			"image": "teleinfo/driver-did-bid",
+			"tag": "1.0.0",
+			"testIdentifiers": [ "did:bid:6cc796b8d6e2fbebc9b3cf9e" ]
 		}
+		
 	]
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -134,6 +134,10 @@ services:
     image: iotex/uni-resolver-driver-did-io:latest
     ports:
       - "8104:8080"
+  driver-did-bid:
+    image: teleinfo/driver-did-bid:1.0.0
+    ports:
+      - "8108:8080"
   uni-resolver-web:
     image: universalresolver/uni-resolver-web:latest
     ports:


### PR DESCRIPTION
Request to add the teleinfo Protocol's DID driver to the Universal Resolver.

The DID Method spec can be read here: https://github.com/teleinfo-bif/bid/tree/master/doc/en

The PR to add the teleinfo DID method to the DID Method Registry is open: https://w3c.github.io/did-spec-registries/#did-methods

Thanks!