### PR TITLE
Add Teleinfo DID Driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,9 @@ You should then be able to resolve identifiers locally using simple `curl` reque
 	curl -X GET http://localhost:8080/1.0/identifiers/did:mpg:7PGGnRdvKKFftSXU3Jw75Vk5npfg
 	curl -X GET http://localhost:8080/1.0/identifiers/did:trust:cert.EiBJ6qjVXgJ-A8xnaUiu4rtLDgeobQYgRWjMV49aCak4HQ
 	curl -X GET http://localhost:8080/1.0/identifiers/did:io:0x476c81C27036D05cB5ebfe30ae58C23351a61C4A
-    curl -X GET http://localhost:8080/1.0/identifiers/did:bba:t:45e6df15dc0a7d91dcccd24fda3b52c3983a214fb0eed0938321c11ec99403cf
+    	curl -X GET http://localhost:8080/1.0/identifiers/did:bba:t:45e6df15dc0a7d91dcccd24fda3b52c3983a214fb0eed0938321c11ec99403cf
 	curl -X GET http://localhost:8080/1.0/identifiers/did:cy:2nnn7H7RJLLhFPoGyzxPCLzuhrzJ
+	curl -X GET http://localhost:8080/1.0/identifiers/did:bid:6cc796b8d6e2fbebc9b3cf9e
 
 
 If this doesn't work, see [Troubleshooting](/docs/troubleshooting.md).

--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ Are you developing a DID method and Universal Resolver driver? Click [Driver Dev
 | [did-io](https://github.com/iotexproject/uni-resolver-driver-did-io) | 0.1.0 | [1.0 WD](https://w3c.github.io/did-core/) | (missing) | [iotex/uni-resolver-driver-did-io](iotex/uni-resolver-driver-did-io:latest)
 | [did-bba](https://github.com/blobaa/bba-did-driver) | 0.2.0 | [1.0 WD](https://w3c.github.io/did-core/) | [1.0](https://github.com/blobaa/bba-did-method-specification/blob/master/docs/markdown/spec.md) | [blobaa/bba-did-driver](https://hub.docker.com/repository/docker/blobaa/bba-did-driver)
 | [did-cy] | 0.1.0 | [1.0 WD](https://w3c.github.io/did-core/) |  | [](chainyard/driver-did-cy:latest)
+| [did-bid](https://github.com/teleinfo-bif/bid-resolver) | 1.0.0 | [1.0 WD](https://w3c.github.io/did-core/) | [1.0.1](https://github.com/teleinfo-bif/bid/tree/master/doc/en) | [teleinfo/driver-did-bid](https://hub.docker.com/repository/docker/teleinfo/driver-did-bid)
+
 
 ## More Information
 

--- a/config.json
+++ b/config.json
@@ -176,6 +176,12 @@
 			"imageProperties": "true",
 			"tag": "latest",
 			"testIdentifiers": [ "did:cy:7PGGnRdvKKFftSXU3Jw75Vk5npfg" ]
-		}
+		},
+	{ 
+	  "pattern": "^(did:bid:)([0-9a-f]{24})", 
+	  "image": "teleinfo/driver-did-bid", 
+	  "tag": "1.0.0", 
+	  "testIdentifiers": [ "did:bid:6cc796b8d6e2fbebc9b3cf9e" ] 
+	  } 
 	]
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -143,6 +143,10 @@ services:
     image: chainyard/driver-did-cy:latest
     ports:
       - "8108:8080"
+  driver-did-bid:
+    image: teleinfo/driver-did-bid:1.0.0
+    ports:
+      - "8109:8080"
   uni-resolver-web:
     image: universalresolver/uni-resolver-web:latest
     ports:


### PR DESCRIPTION
Request to add the teleinfo Protocol's DID driver to the Universal Resolver.

The DID Method spec can be read here: https://github.com/teleinfo-bif/bid/tree/master/doc/en

The PR to add the teleinfo DID method to the DID Method Registry is open: https://w3c.github.io/did-spec-registries/#did-methods

Thanks!

Fixes #138 
  We have updated the docker image in hub and updated ports,readme file according latest master branch versions. Please repull the docker image and deploy it . Thank u very much.