### PR TITLE
add did:schema driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ You should then be able to resolve identifiers locally using simple `curl` reque
 	curl -X GET http://localhost:8080/1.0/identifiers/did:io:0x476c81C27036D05cB5ebfe30ae58C23351a61C4A
     curl -X GET http://localhost:8080/1.0/identifiers/did:bba:t:45e6df15dc0a7d91dcccd24fda3b52c3983a214fb0eed0938321c11ec99403cf
 	curl -X GET http://localhost:8080/1.0/identifiers/did:cy:2nnn7H7RJLLhFPoGyzxPCLzuhrzJ
+	curl -X GET http://localhost:8080/1.0/identifiers/did:schema:public-ipfs:xsd:QmUQAxKQ5sbWWrcBZzwkThktfUGZvuPQyTrqMzb3mZnLE5
 
 
 If this doesn't work, see [Troubleshooting](/docs/troubleshooting.md).
@@ -90,6 +91,7 @@ Are you developing a DID method and Universal Resolver driver? Click [Driver Dev
 | [did-io](https://github.com/iotexproject/uni-resolver-driver-did-io) | 0.1.0 | [1.0 WD](https://w3c.github.io/did-core/) | (missing) | [iotex/uni-resolver-driver-did-io](iotex/uni-resolver-driver-did-io:latest)
 | [did-bba](https://github.com/blobaa/bba-did-driver) | 0.2.0 | [1.0 WD](https://w3c.github.io/did-core/) | [1.0](https://github.com/blobaa/bba-did-method-specification/blob/master/docs/markdown/spec.md) | [blobaa/bba-did-driver](https://hub.docker.com/repository/docker/blobaa/bba-did-driver)
 | [did-cy] | 0.1.0 | [1.0 WD](https://w3c.github.io/did-core/) |  | [](chainyard/driver-did-cy:latest)
+| [did-schema](https://github.com/51nodes/schema-registry-did-resolver) | 0.1.0 | [1.0 WD](https://w3c.github.io/did-core/) | [0.1](https://github.com/51nodes/schema-registry-did-method) | [51nodes/schema-registry-did-resolver](https://hub.docker.com/repository/docker/51nodes/schema-registry-did-resolver)
 
 ## More Information
 

--- a/config.json
+++ b/config.json
@@ -176,6 +176,12 @@
 			"imageProperties": "true",
 			"tag": "latest",
 			"testIdentifiers": [ "did:cy:7PGGnRdvKKFftSXU3Jw75Vk5npfg" ]
+		},
+		{
+			"pattern": "^(did:schema:.+)$",
+			"image": "51nodes/schema-registry-did-resolver",
+			"tag": "latest",
+			"testIdentifiers": [ "did:schema:public-ipfs:xsd:QmUQAxKQ5sbWWrcBZzwkThktfUGZvuPQyTrqMzb3mZnLE5", "did:schema:evan-ipfs:xsd:QmUQAxKQ5sbWWrcBZzwkThktfUGZvuPQyTrqMzb3mZnLE5" ]
 		}
 	]
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -145,6 +145,10 @@ services:
     image: chainyard/driver-did-cy:latest
     ports:
       - "8108:8080"
+  schema-registry-did-resolver:
+    image: 51nodes/schema-registry-did-resolver
+    ports:
+      - "8109:8080"
   uni-resolver-web:
     image: universalresolver/uni-resolver-web:latest
     ports:


### PR DESCRIPTION
Request to add the schema did driver to the Universal Resolver.

The DID Method spec: https://github.com/51nodes/schema-registry-did-method/blob/master/README.md

The DID Driver Implementation: https://github.com/51nodes/schema-registry-did-resolver

The DID Driver Image: https://hub.docker.com/repository/docker/51nodes/schema-registry-did-resolver

The PR to add the Schema DID method to the DID Method Registry is already merged: https://w3c.github.io/did-spec-registries/#did-methods