### PR TITLE
Allow missing Accept header

### DIFF
--- a/resolver/java/uni-resolver-web/src/main/java/uniresolver/web/servlet/ResolveServlet.java
+++ b/resolver/java/uni-resolver-web/src/main/java/uniresolver/web/servlet/ResolveServlet.java
@@ -83,7 +83,8 @@ public class ResolveServlet extends WebUniResolver {
 
 		// write resolve result
 
-		if (request.getHeader("Accept").contains(DIDDocument.MIME_TYPE) && resolveResult.getDidDocument() != null) {
+		String acceptHeader = request.getHeader("Accept");
+		if ((acceptHeader == null || acceptHeader.contains(DIDDocument.MIME_TYPE)) && resolveResult.getDidDocument() != null) {
 
 			WebUniResolver.sendResponse(response, HttpServletResponse.SC_OK, DIDDocument.MIME_TYPE, resolveResultString);
 			return;


### PR DESCRIPTION
If the HTTP Accept header is missing, the response would fail with a NullPointerException. Steps to reproduce:
```
curl -H 'Accept:' 'https://dev.uniresolver.io/1.0/identifiers/did:key:z6Mkfriq1MqLBoPWecGoDLjguo1sB9brj6wT3qZ5BxkKpuP6'
```
This patch checks that the header is not null before examining it. A client not sending a Accept header is treated as accepting the native DID Document media type.