### PR TITLE
use version 0.1.1 of schema driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ You should then be able to resolve identifiers locally using simple `curl` reque
     curl -X GET http://localhost:8080/1.0/identifiers/did:bba:t:45e6df15dc0a7d91dcccd24fda3b52c3983a214fb0eed0938321c11ec99403cf
 	curl -X GET http://localhost:8080/1.0/identifiers/did:cy:2nnn7H7RJLLhFPoGyzxPCLzuhrzJ
 	curl -X GET http://localhost:8080/1.0/identifiers/did:bid:6cc796b8d6e2fbebc9b3cf9e
-	curl -X GET http://localhost:8080/1.0/identifiers/did:schema:public-ipfs:xsd:QmUQAxKQ5sbWWrcBZzwkThktfUGZvuPQyTrqMzb3mZnLE5
+	curl -X GET http://localhost:8080/1.0/identifiers/did:schema:public-ipfs:json-schema:Qma2beXKwZeiUXcaRaQKwbBV1TqyiJnsMTYExUTdQue43J
 
 
 If this doesn't work, see [Troubleshooting](/docs/troubleshooting.md).
@@ -95,7 +95,7 @@ Are you developing a DID method and Universal Resolver driver? Click [Driver Dev
 | [did-bba](https://github.com/blobaa/bba-did-driver) | 0.2.0 | [1.0 WD](https://w3c.github.io/did-core/) | [1.0](https://github.com/blobaa/bba-did-method-specification/blob/master/docs/markdown/spec.md) | [blobaa/bba-did-driver](https://hub.docker.com/repository/docker/blobaa/bba-did-driver)
 | [did-cy] | 0.1.0 | [1.0 WD](https://w3c.github.io/did-core/) |  | [](chainyard/driver-did-cy:latest)
 | [did-bid](https://github.com/teleinfo-bif/bid-resolver) | 1.0.0 | [1.0 WD](https://w3c.github.io/did-core/) | [1.0.1](https://github.com/teleinfo-bif/bid/tree/master/doc/en) | [teleinfo/driver-did-bid](https://hub.docker.com/repository/docker/teleinfo/driver-did-bid)
-| [did-schema](https://github.com/51nodes/schema-registry-did-resolver) | 0.1.0 | [1.0 WD](https://w3c.github.io/did-core/) | [0.1](https://github.com/51nodes/schema-registry-did-method) | [51nodes/schema-registry-did-resolver](https://hub.docker.com/repository/docker/51nodes/schema-registry-did-resolver)
+| [did-schema](https://github.com/51nodes/schema-registry-did-resolver) | 0.1.1 | [1.0 WD](https://w3c.github.io/did-core/) | [0.1](https://github.com/51nodes/schema-registry-did-method) | [51nodes/schema-registry-did-resolver](https://hub.docker.com/repository/docker/51nodes/schema-registry-did-resolver)
 
 ## More Information
 

--- a/config.json
+++ b/config.json
@@ -186,8 +186,8 @@
 		{
 			"pattern": "^(did:schema:.+)$",
 			"image": "51nodes/schema-registry-did-resolver",
-			"tag": "latest",
-			"testIdentifiers": [ "did:schema:public-ipfs:xsd:QmUQAxKQ5sbWWrcBZzwkThktfUGZvuPQyTrqMzb3mZnLE5", "did:schema:evan-ipfs:xsd:QmUQAxKQ5sbWWrcBZzwkThktfUGZvuPQyTrqMzb3mZnLE5" ]
+			"tag": "0.1.1",
+			"testIdentifiers": [ "did:schema:public-ipfs:json-schema:Qma2beXKwZeiUXcaRaQKwbBV1TqyiJnsMTYExUTdQue43J", "did:schema:evan-ipfs:json-schema:Qma2beXKwZeiUXcaRaQKwbBV1TqyiJnsMTYExUTdQue43J" ]
 		}
 	]
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -150,7 +150,7 @@ services:
     ports:
       - "8109:8080"
   schema-registry-did-resolver:
-    image: 51nodes/schema-registry-did-resolver
+    image: 51nodes/schema-registry-did-resolver:0.1.1
     ports:
       - "8110:8080"
   uni-resolver-web:


### PR DESCRIPTION
Hi, we released a new version of our driver for the did:schema method and changed the examples
update from 0.1.0 to 0.1.1