### PR TITLE
Update did:icon driver to 0.1.2

### DIFF
--- a/.env
+++ b/.env
@@ -30,6 +30,6 @@ DID_METHOD_MODE=resolver
 
 UNIRESOLVER_DRIVER_DID_ACE=prod
 
-uniresolver_driver_did_icon_node_url=https://ctz.solidwallet.io/api/v3
-uniresolver_driver_did_icon_score_addr=cx694e8c9f1a05c8c3719f30d46b97697960e4289e
-uniresolver_driver_did_icon_network_id=1
+uniresolver_driver_did_icon_node_url=https://test-ctz.solidwallet.io/api/v3
+uniresolver_driver_did_icon_score_addr=cx8b19bdb4e1ad3e10b599d8887dd256e02995f340
+uniresolver_driver_did_icon_network_id=2

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Are you developing a DID method and Universal Resolver driver? Click [Driver Dev
 | [did-ion](https://github.com/decentralized-identity/uni-resolver-driver-did-ion) | 0.8.1 | [1.0 WD](https://w3c.github.io/did-core/) | [0.1](https://github.com/decentralized-identity/ion) | [identityfoundation/driver-did-ion](https://hub.docker.com/r/identityfoundation/driver-did-ion)
 | [did-ace](https://github.com/aceblockID/aceblock-did-resolver)| 1.0 | [1.0 WD](https://w3c.github.io/did-core/) |(missing) | [aceblock/ace-did-driver](https://hub.docker.com/r/aceblock/ace-did-driver)
 | [did-gatc](https://github.com/gataca-io/universal-resolver-driver) | 1.0.0 | [1.0 WD](https://w3c.github.io/did-core/) | [1.0 WD](https://github.com/gatacaid/gataca-did-method) | [gatacaid/universal-resolver-driver](https://hub.docker.com/r/gatacaid/universal-resolver-driver)
-| [did-icon](https://github.com/amuyu/uni-resolver-driver-did-icon) | 0.1.1 | [1.0 WD](https://w3c.github.io/did-core/) | [1.0 WD](https://github.com/icon-project/icon-DID/blob/master/docs/ICON-DID-method.md) | [amuyu/driver-did-icon](https://hub.docker.com/r/amuyu/driver-did-icon)
+| [did-icon-zzeung](https://github.com/amuyu/uni-resolver-driver-did-icon) | 0.1.2 | [1.0 WD](https://w3c.github.io/did-core/) | [1.0 WD](https://github.com/icon-project/icon-DID/blob/master/docs/ICON-DID-method.md) | [amuyu/driver-did-icon](https://hub.docker.com/r/amuyu/driver-did-icon)
 | [did-vaa](https://github.com/caict-develop-zhangbo/uni-resolver-driver-did-vaa)|1.0.0|[1.0 WD](https://w3c.github.io/did-core/)|[1.0 WD](https://github.com/caict-develop-zhangbo/vaa-method)|[caict/driver-did-vaa](https://hub.docker.com/repository/docker/caictdevelop/driver-did-vaa)
 
 ## More Information

--- a/config.json
+++ b/config.json
@@ -203,10 +203,10 @@
 			"testIdentifiers": [ "did:gatc:2xtSori9UQZdTqzxrkp7zqKM4Kj5B4C7" ]
 		},
 		{
-			"pattern": "^(did:icon:.+)$",
+			"pattern": "^(did:icon:02:.+)$",
 			"image": "amuyu/driver-did-icon",
-			"tag": "0.1.1",
-			"testIdentifiers": [ "did:icon:01:64aa0a2a479cb47afbf2d18d6f9f216bcdcbecdda27ccba3", "did:icon:02:6f7a00a29deb82cb36d501d687c18bad79a8f1c154ef0c78" ]
+			"tag": "0.1.2",
+			"testIdentifiers": [ "did:icon:02:6f7a00a29deb82cb36d501d687c18bad79a8f1c154ef0c78" ]
 		},
 		{
 			"pattern": "^(did:vaa:.+)$",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -174,7 +174,7 @@ services:
     ports:
       - "8113:8080"
   driver-did-icon:
-    image: amuyu/driver-did-icon:0.1.1
+    image: amuyu/driver-did-icon:0.1.2
     environment:
       uniresolver_driver_did_icon_node_url: ${uniresolver_driver_did_icon_node_url}
       uniresolver_driver_did_icon_score_addr: ${uniresolver_driver_did_icon_score_addr}


### PR DESCRIPTION

New features:
- When resolving, add document metadata
example:
```
    "didDocumentMetadata": {
        "nodeUrl": "https://test-ctz.solidwallet.io/api/v3",
        "scoreAddress": "cx8b19bdb4e1ad3e10b599d8887dd256e02995f340",
        "service": {
            "id": "ZZEUNG",
            "serviceEndpoint": "https://zzeung.id/#/"
        }
    }
```

Changes:
This driver will be used for identifiers using `zzeung` services. 
The official `did:icon` driver that uses the mainnet network is planned to be addes with a different driver name.
