### PR TITLE
Update KILT DID Driver

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,7 +76,7 @@ services:
     ports:
       - "8093:8080"
   kilt-did-driver:
-    image: kiltprotocol/kilt-did-driver:1.2.1
+    image: kiltprotocol/kilt-did-driver:1.3.0
     environment:
       uniresolver_driver_kilt_did_node: ${uniresolver_driver_kilt_did_node}
     ports:


### PR DESCRIPTION
We updated our chain, wich introduced some breaking changes for the did driver.
Old DIDs are still resolvable, so no need for a new example.

This PR updates our driver to the latest version.