### PR TITLE
Rename SOLID method to SOL

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ You should then be able to resolve identifiers locally using simple `curl` reque
 	curl -X GET http://localhost:8080/1.0/identifiers/did:vaa:3wJVWDQWtDFx27FqvSqyo5xsTsxC
 	curl -X GET http://localhost:8080/1.0/identifiers/did:unisot:1EjHm7VtgsqNzCkvA8XRgGXZ1UKo1txSM4
 	curl -X GET http://localhost:8080/1.0/identifiers/did:bitxhub:appchain001:0xc7F999b83Af6DF9e67d0a37Ee7e900bF38b3D013
-	curl -X GET http://localhost:8080/1.0/identifiers/did:solid:DSb8Guj9tB1jvsyqrsE3Yi44hwnzrVVQc2gcS1J1dUxy
+	curl -X GET http://localhost:8080/1.0/identifiers/did:sol:ygGfLvAyuRymPNv2fJDK1ZMpdy59m8cV5dak6A8uHKa
 	curl -X GET http://localhost:8080/1.0/identifiers/did:lit:AEZ87t1bi5bRxmVh3ksMUi
 
 If this doesn't work, see [Troubleshooting](/docs/troubleshooting.md).
@@ -115,7 +115,7 @@ Are you developing a DID method and Universal Resolver driver? Click [Driver Dev
 | [did-vaa](https://github.com/caict-develop-zhangbo/uni-resolver-driver-did-vaa)|1.0.0|[1.0 WD](https://w3c.github.io/did-core/)|[1.0 WD](https://github.com/caict-develop-zhangbo/vaa-method)|[caict/driver-did-vaa](https://hub.docker.com/repository/docker/caictdevelop/driver-did-vaa)
 | [did-unisot](https://gitlab.com/unisot-did/unisot-did-driver)|1.0.0|[1.0 WD](https://w3c.github.io/did-core/)|[1.0.0](https://gitlab.com/unisot-did/unisot-did-method-specification)|[unisot/unisot-did-driver](https://hub.docker.com/r/unisot/unisot-did-driver)
 | [did-bitxhub](https://github.com/meshplus/driver-did-bitxhub) | 1.0.0 | [1.0.0 WD](https://w3c.github.io/did-core/) | (missing) | [meshplus/driver-did-bitxhub](https://hub.docker.com/repository/docker/meshplus/driver-did-bitxhub) |
-| [did-solid](https://github.com/identity-com/solid-did)|1.0.0|[1.0 WD](https://w3c.github.io/did-core/)|[1.0.0](https://github.com/identity-com/solid-did/)|[identitydotcom/driver-did-solid](https://hub.docker.com/r/identitydotcom/driver-did-solid)
+| [did-sol](https://github.com/identity-com/sol-did)|1.0.0|[1.0 WD](https://w3c.github.io/did-core/)|[1.0.0](https://github.com/identity-com/sol-did/)|[identitydotcom/driver-did-sol](https://hub.docker.com/r/identitydotcom/driver-did-sol)
 | [did-lit](https://github.com/ibct-dev/lit-resolver) | 0.1.0 | [1.0 WD](https://w3c.github.io/did-core/) | [0.1.0](https://github.com/ibct-dev/lit-DID/blob/main/docs/did:lit-method-spec_eng_v0.1.0.md) | [ibct/driver-did-lit](https://hub.docker.com/r/ibct/driver-did-lit)
 
 ## More Information

--- a/config.json
+++ b/config.json
@@ -203,9 +203,9 @@
 			"testIdentifiers": [ "did:bitxhub:appchain001:0xc7F999b83Af6DF9e67d0a37Ee7e900bF38b3D013" ]
 		},
         {
-          "pattern": "^(did:solid:.+)$",
-          "url": "http://driver-did-solid:8080/",
-          "testIdentifiers": [ "did:solid:DSb8Guj9tB1jvsyqrsE3Yi44hwnzrVVQc2gcS1J1dUxy" ]
+          "pattern": "^(did:sol:.+)$",
+          "url": "http://driver-did-sol:8080/",
+          "testIdentifiers": [ "did:sol:ygGfLvAyuRymPNv2fJDK1ZMpdy59m8cV5dak6A8uHKa" ]
         },
         {
           "pattern": "^(did:lit:(?:[1-9A-HJ-NP-Za-km-z]{21,22}))$",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -193,8 +193,8 @@ services:
     image: meshplus/driver-did-bitxhub:latest
     ports:
       - "8117:8080"
-  driver-did-solid:
-    image: identitydotcom/driver-did-solid:0.1.0
+  driver-did-sol:
+    image: identitydotcom/driver-did-sol:0.1.0
     ports:
       - "8118:8080"
   driver-did-lit:


### PR DESCRIPTION
Rename the SOLID driver to SOL to avoid clashes with https://solidproject.org/