### PR TITLE
remove driver-specific dependencies from BOM file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,11 +84,9 @@
 		<fasterxml.jackson.version>2.11.2</fasterxml.jackson.version>
 		<gson.version>2.8.6</gson.version>
 		<commons-codec.version>1.14</commons-codec.version>
-		<google.guava.version>29.0-jre</google.guava.version>
 		<httpclient.version>4.5.12</httpclient.version>
 		<javax.servlet.version>2.5</javax.servlet.version>
 		<springframework.version>5.2.9.RELEASE</springframework.version>
-		<io.leonard-base58.version>0.0.2</io.leonard-base58.version>
 		<junit.version>4.13.1</junit.version>
 
 		<!-- Plugin Versions -->
@@ -285,16 +283,6 @@
 				<groupId>commons-codec</groupId>
 				<artifactId>commons-codec</artifactId>
 				<version>${commons-codec.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>com.google.guava</groupId>
-				<artifactId>guava</artifactId>
-				<version>${google.guava.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>io.leonard</groupId>
-				<artifactId>base58</artifactId>
-				<version>${io.leonard-base58.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>javax.servlet</groupId>


### PR DESCRIPTION
Driver-specific dependencies that are not used in universal-resolver should be removed from the BOM file.