### PR TITLE
Add DIDKit driver and did:tz

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ You should then be able to resolve identifiers locally using simple `curl` reque
 	curl -X GET http://localhost:8080/1.0/identifiers/did:ebsi:DfPaUdYwuzcqFoiMDSrUX8aQyZnr2SesH3vDVASYv8PE
 	curl -X GET http://localhost:8080/1.0/identifiers/did:emtrust:0x242a5ac36676462bd58a
 	curl -X GET http://localhost:8080/1.0/identifiers/did:meta:0000000000000000000000000000000000000000000000000000000000005e65
+	curl -X GET http://localhost:8080/1.0/identifiers/did:tz:tz1YwA1FwpgLtc1G8DKbbZ6e6PTb1dQMRn5x
 
 If this doesn't work, see [Troubleshooting](/docs/troubleshooting.md).
 
@@ -120,6 +121,7 @@ Are you developing a DID method and Universal Resolver driver? Click [Driver Dev
 | [did-ebsi](https://api.preprod.ebsi.eu/docs/#/DID%20Registry) | 2.0.0 | 2.0.0 | [URL](https://api.preprod.ebsi.eu/did-registry/v2/identifiers/) |
 | [did-emtrust](https://github.com/Halialabs/did-spec) | 0.1| 0.1 | [halialabsdev/emtrust_did_driver](https://hub.docker.com/r/halialabsdev/emtrust_did_driver) |
 | [did-meta](https://github.com/METADIUM/meta-DID/blob/master/doc/DID-method-metadium.md) | 1.0 | 1.0 | [URL](https://resolver.metadium.com/1.0/identifiers/) |
+| [did-tz](https://github.com/spruceid/ssi/tree/main/did-tezos/) | 0.1.0 | [1.0 CR Draft 20210627](https://www.w3.org/TR/2021/CRD-did-core-20210627/) | [0.1](https://did-tezos.spruceid.com/) | [ghcr.io/spruceid/didkit-http](https://github.com/orgs/spruceid/packages/container/package/didkit-http)
 
 ## More Information
 

--- a/config.json
+++ b/config.json
@@ -108,7 +108,7 @@
 			"url": "http://uni-resolver-driver-did-echo:8080/",
 			"testIdentifiers": [ "did:echo:1.1.25.0" ]
 		}, {
-			"pattern": "^(did:key:.+)$",
+			"pattern": "^(did:key:z6Mk.+)$",
 			"url": "http://driver-did-key:8080/",
 			"testIdentifiers": [ "did:key:z6Mkfriq1MqLBoPWecGoDLjguo1sB9brj6wT3qZ5BxkKpuP6", "did:key:z6MksQ35B5bwZDQq4QKuhQW2Sv6dcqwg4PqcSFf67pdgrtjB", "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH" ]
 		}, {
@@ -223,6 +223,18 @@
 			"pattern": "^(did:meta:.+)$",
 			"url": "https://resolver.metadium.com/1.0/identifiers/$1",
 			"testIdentifiers": [ "did:meta:0000000000000000000000000000000000000000000000000000000000005e65" ]
+		},
+		{
+			"pattern": "^did:(?:tz:|web:|key:(?:z6Mk|zQ3s|zDna)).+$",
+			"url": "http://driver-didkit:8080/identifiers/$1",
+			"testIdentifiers": [
+				"did:tz:tz1YwA1FwpgLtc1G8DKbbZ6e6PTb1dQMRn5x",
+				"did:tz:delphinet:tz1WvvbEGpBXGeTVbLiR6DYBe1izmgiYuZbq",
+				"did:web:identity.foundation",
+				"did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH",
+				"did:key:zQ3shokFTS3brHcDQrn82RUDfCZESWL1ZdCEJwekUDPQiYBme",
+				"did:key:zDnaerDaTF5BXEavCrfRZEk316dpbLsfPDZ3WJ5hRTPFU2169"
+			]
 		}
 	]
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -200,3 +200,10 @@ services:
     image: halialabsdev/emtrust_did_driver:latest
     ports:
       - "8120:8080"
+  driver-didkit:
+    image: ghcr.io/spruceid/didkit-http:latest
+    environment:
+      PORT: 8080
+      HOST: 0.0.0.0
+    ports:
+      - "8121:8080"


### PR DESCRIPTION
Add driver using [DIDKit](https://github.com/spruceid/didkit/) from [GitHub Container Registry](https://github.com/spruceid/didkit/pkgs/container/didkit-http).

[DIDKit's HTTP server](https://github.com/spruceid/didkit/tree/main/http/) includes support for several DID methods. The main one added here to the Universal Resolver's table of supported DID methods is [did:tz](https://did-tezos.spruceid.com/) (Tezos DID Method).

Also update the config to use DIDKit to resolve `did:key` prefixes `zQ3s` ([secp256k1](https://w3c-ccg.github.io/did-method-key/#secp256k1)) and `zDna` (compressed [P-256](https://github.com/w3c-ccg/did-method-key/pull/38)), since the Universal Resolver's [did:key driver](https://github.com/decentralized-identity/uni-resolver-driver-did-key) only supports Ed25519 (`z6Mk`), 

DIDKit `did:web` test DIDs are also listed in the config, although the config is not set to use DIDKit for `did:web`.

Close https://github.com/spruceid/didkit/issues/138