### PR TITLE
Updated `driver-did-sol` to version `0.1.1`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -188,7 +188,7 @@ services:
     ports:
       - "8117:8080"
   driver-did-sol:
-    image: identitydotcom/driver-did-sol:0.1.0
+    image: identitydotcom/driver-did-sol:0.1.1
     ports:
       - "8118:8080"
   driver-did-lit:


### PR DESCRIPTION
Updates `driver-did-sol` to version `0.1.1`. This changes the old api address for Solana to the new api address.