### PR TITLE
Add note about frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ You should then be able to resolve identifiers locally using simple `curl` reque
 
 If this doesn't work, see [Troubleshooting](/docs/troubleshooting.md).
 
+Note that there is also a [Universal Resolver frontend](https://github.com/decentralized-identity/universal-resolver-frontend/) that can optionally be installed separately.
+
 ## Drivers
 
 Are you developing a DID method and Universal Resolver driver? Click [Driver Development](/docs/driver-development.md) for instructions.


### PR DESCRIPTION
It is not clear that the frontend has to be installed separately (see question in https://github.com/decentralized-identity/universal-resolver/issues/193). This PR adds a note to fix this.