### PR TITLE
Add Dock DID driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ You should then be able to resolve identifiers locally using simple `curl` reque
 	curl -X GET http://localhost:8080/1.0/identifiers/did:tz:tz1YwA1FwpgLtc1G8DKbbZ6e6PTb1dQMRn5x
 	curl -X GET http://localhost:8080/1.0/identifiers/did:pkh:tz:tz2BFTyPeYRzxd5aiBchbXN3WCZhx7BqbMBq
 	curl -X GET http://localhost:8080/1.0/identifiers/did:orb:hl:uEiDI6sZJnp44sC_BG2XekWA4TN2m0Wtwv8AI71UER3vCHw:uoQ-BeEJpcGZzOi8vYmFma3JlaWdpNWxkZXRodTZoY3ljN3FpM214cGpjeWJ5anRvMm51bGxvYzc0YWNocGt1Y2VvNjZjZDQ:EiClaNSwhKSP6tQe36bYc5w41oRpCi1xv89MkUnNBm8agw
+	curl -X GET http://localhost:8080/1.0/identifiers/did:dock:5EAp6DB2pkKuAfbhQiqAXFY4XPZkJrvtWKad4ChDmWwDrC8n
 
 You can also use an "Accept" header to request the DID document in a specific representation, e.g.:
 
@@ -117,7 +118,8 @@ Are you developing a DID method and Universal Resolver driver? Click [Driver Dev
 | [did-meta](https://github.com/METADIUM/meta-DID/blob/master/doc/DID-method-metadium.md) | 1.0 | 1.0 | [URL](https://resolver.metadium.com/1.0/identifiers/) | Metadium Decentralized Identifiers
 | [did-tz](https://github.com/spruceid/ssi/tree/main/did-tezos/) | 0.1.0 | [0.1](https://did-tezos.spruceid.com/) | [ghcr.io/spruceid/didkit-http](https://github.com/orgs/spruceid/packages/container/package/didkit-http) | Tezos DID method
 | [did-pkh](https://github.com/spruceid/ssi/tree/main/did-pkh/) | 0.0.1 | [0.1](https://github.com/spruceid/ssi/blob/main/did-pkh/did-pkh-method-draft.md) | [ghcr.io/spruceid/didkit-http](https://github.com/orgs/spruceid/packages/container/package/didkit-http) | Public Key Hash DID method
-| [did-orb](https://github.com/trustbloc/orb/releases/tag/v0.1.3) | 0.1.3 | [0.2](https://trustbloc.github.io/did-method-orb/) | [trustbloc/orb-did-driver](https://github.com/orgs/trustbloc-cicd/packages/container/package/orb-did-driver) | 
+| [did-orb](https://github.com/trustbloc/orb/releases/tag/v0.1.3) | 0.1.3 | [0.2](https://trustbloc.github.io/did-method-orb/) | [trustbloc/orb-did-driver](https://github.com/orgs/trustbloc-cicd/packages/container/package/orb-did-driver) |
+| [did-dock](https://github.com/docknetwork/dock-did-driver) | 1.0.0 | [1.0 WD](https://w3c.github.io/did-core/) | [0.1](https://github.com/docknetwork/dock-did-driver/blob/master/Dock%20DID%20method%20specification.md) | [docknetwork/dock-did-driver](https://hub.docker.com/r/docknetwork/dock-did-driver) |
 
 
 ## More Information

--- a/config.json
+++ b/config.json
@@ -201,7 +201,7 @@
 		},
 		{
 			"pattern": "^(did:dock:.+)$",
-			"url": "http://dock-did-driver:8099/1.0/identifiers/$1",
+			"url": "http://dock-did-driver:8080/1.0/identifiers/$1",
 			"testIdentifiers": [ "did:dock:5EAp6DB2pkKuAfbhQiqAXFY4XPZkJrvtWKad4ChDmWwDrC8n", "did:dock:5CDsD8HZa6TeSfgmMcxAkbSXYWeob4jFQmtU6sxr4XWTZzUA" ]
 		}
 	]

--- a/config.json
+++ b/config.json
@@ -194,8 +194,9 @@
 			"url": "http://orb-did-driver:8121/resolveDID?did=$1",
 			"testIdentifiers": [ "did:orb:hl:uEiDI6sZJnp44sC_BG2XekWA4TN2m0Wtwv8AI71UER3vCHw:uoQ-BeEJpcGZzOi8vYmFma3JlaWdpNWxkZXRodTZoY3ljN3FpM214cGpjeWJ5anRvMm51bGxvYzc0YWNocGt1Y2VvNjZjZDQ:EiClaNSwhKSP6tQe36bYc5w41oRpCi1xv89MkUnNBm8agw" ]
 		},
-    {
+		{
 			"pattern": "^(did:dock:[a-zA-Z0-9]+)$",
+			"url": "http://dock-did-driver:8099/1.0/identifiers/$1"",
 			"image": "docknetwork/dock-did-driver",
 			"tag": "latest",
 			"testIdentifiers": [ "did:dock:5EAp6DB2pkKuAfbhQiqAXFY4XPZkJrvtWKad4ChDmWwDrC8n", "did:dock:5CDsD8HZa6TeSfgmMcxAkbSXYWeob4jFQmtU6sxr4XWTZzUA" ]

--- a/config.json
+++ b/config.json
@@ -202,8 +202,6 @@
 		{
 			"pattern": "^(did:dock:.+)$",
 			"url": "http://dock-did-driver:8099/1.0/identifiers/$1"",
-			"image": "docknetwork/dock-did-driver",
-			"tag": "latest",
 			"testIdentifiers": [ "did:dock:5EAp6DB2pkKuAfbhQiqAXFY4XPZkJrvtWKad4ChDmWwDrC8n", "did:dock:5CDsD8HZa6TeSfgmMcxAkbSXYWeob4jFQmtU6sxr4XWTZzUA" ]
 		}
 	]

--- a/config.json
+++ b/config.json
@@ -195,7 +195,7 @@
 			"testIdentifiers": [ "did:orb:hl:uEiDI6sZJnp44sC_BG2XekWA4TN2m0Wtwv8AI71UER3vCHw:uoQ-BeEJpcGZzOi8vYmFma3JlaWdpNWxkZXRodTZoY3ljN3FpM214cGpjeWJ5anRvMm51bGxvYzc0YWNocGt1Y2VvNjZjZDQ:EiClaNSwhKSP6tQe36bYc5w41oRpCi1xv89MkUnNBm8agw" ]
 		},
 		{
-			"pattern": "^(did:dock:[a-zA-Z0-9]+)$",
+			"pattern": "^(did:dock:.+)$",
 			"url": "http://dock-did-driver:8099/1.0/identifiers/$1"",
 			"image": "docknetwork/dock-did-driver",
 			"tag": "latest",

--- a/config.json
+++ b/config.json
@@ -193,6 +193,12 @@
 			"pattern": "^(did:orb:.+)$",
 			"url": "http://orb-did-driver:8121/resolveDID?did=$1",
 			"testIdentifiers": [ "did:orb:hl:uEiDI6sZJnp44sC_BG2XekWA4TN2m0Wtwv8AI71UER3vCHw:uoQ-BeEJpcGZzOi8vYmFma3JlaWdpNWxkZXRodTZoY3ljN3FpM214cGpjeWJ5anRvMm51bGxvYzc0YWNocGt1Y2VvNjZjZDQ:EiClaNSwhKSP6tQe36bYc5w41oRpCi1xv89MkUnNBm8agw" ]
+		},
+    {
+			"pattern": "^(did:dock:[a-zA-Z0-9]+)$",
+			"image": "docknetwork/dock-did-driver",
+			"tag": "latest",
+			"testIdentifiers": [ "did:dock:5EAp6DB2pkKuAfbhQiqAXFY4XPZkJrvtWKad4ChDmWwDrC8n", "did:dock:5CDsD8HZa6TeSfgmMcxAkbSXYWeob4jFQmtU6sxr4XWTZzUA" ]
 		}
 	]
 }

--- a/config.json
+++ b/config.json
@@ -201,7 +201,7 @@
 		},
 		{
 			"pattern": "^(did:dock:.+)$",
-			"url": "http://dock-did-driver:8099/1.0/identifiers/$1"",
+			"url": "http://dock-did-driver:8099/1.0/identifiers/$1",
 			"testIdentifiers": [ "did:dock:5EAp6DB2pkKuAfbhQiqAXFY4XPZkJrvtWKad4ChDmWwDrC8n", "did:dock:5CDsD8HZa6TeSfgmMcxAkbSXYWeob4jFQmtU6sxr4XWTZzUA" ]
 		}
 	]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -172,3 +172,7 @@ services:
     ports:
       - "8121:8121"
     command: start
+  dock-did-driver:
+    image: docknetwork/dock-did-driver:latest
+    ports:
+      - "8099:8080"


### PR DESCRIPTION
This PR re-adds the `did:dock` driver which has been updated for the latest PoS network and shouldnt be as unstable as previous version. I am now maintaing that repo so it should be kept upto date more often