### PR TITLE
Update did:icon driver to 0.1.3

### DIFF
--- a/.env
+++ b/.env
@@ -30,9 +30,9 @@ DID_METHOD_MODE=resolver
 
 UNIRESOLVER_DRIVER_DID_ACE=prod
 
-uniresolver_driver_did_icon_node_url=https://test-ctz.solidwallet.io/api/v3
-uniresolver_driver_did_icon_score_addr=cx8b19bdb4e1ad3e10b599d8887dd256e02995f340
-uniresolver_driver_did_icon_network_id=2
+uniresolver_driver_did_icon_node_url=https://sejong.net.solidwallet.io/api/v3
+uniresolver_driver_did_icon_score_addr=cxc7c8b0bb85eca64aecc8cc38628c4bc3c449f1fd
+uniresolver_driver_did_icon_network_id=83
 
 LEDGIS_LIT_ENDPOINT=https://lit.ledgis.io
 LEDGIS_LIT_CODE=lit

--- a/config.json
+++ b/config.json
@@ -136,9 +136,9 @@
 			"testIdentifiers": [ "did:gatc:2xtSori9UQZdTqzxrkp7zqKM4Kj5B4C7" ]
 		},
 		{
-			"pattern": "^(did:icon:02:.+)$",
+			"pattern": "^(did:icon:.+)$",
 			"url": "http://driver-did-icon:8080/",
-			"testIdentifiers": [ "did:icon:02:6f7a00a29deb82cb36d501d687c18bad79a8f1c154ef0c78" ]
+			"testIdentifiers": [ "did:icon:01:64aa0a2a479cb47afbf2d18d6f9f216bcdcbecdda27ccba3" ]
 		},
 		{
 			"pattern": "^(did:vaa:.+)$",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -121,7 +121,7 @@ services:
     ports:
       - "8113:8080"
   driver-did-icon:
-    image: amuyu/driver-did-icon:0.1.2
+    image: amuyu/driver-did-icon:0.1.3
     environment:
       uniresolver_driver_did_icon_node_url: ${uniresolver_driver_did_icon_node_url}
       uniresolver_driver_did_icon_score_addr: ${uniresolver_driver_did_icon_score_addr}


### PR DESCRIPTION
With the release of icon blockchain 2.0, the original testnet using icon 1.0 no longer operates. 
So, the driver has been modified so that did can be retrieved in the new testnet network environment.

* old : https://test-ctz.solidwallet.io/api/v3
* new : https://sejong.net.solidwallet.io/api/v3