### PR TITLE
feat: update KILT driver to v2.2.0

### DIFF
--- a/.env
+++ b/.env
@@ -16,7 +16,7 @@ uniresolver_driver_did_erc725_etherscanApis=mainnet;http://api.etherscan.io/api;
 uniresolver_driver_did_work_apikey=sxVQUoDE015VhAs5ep4b57DFA5vT3zqvf1Dm1sGe
 uniresolver_driver_did_work_domain=https://credentials.id.workday.com
 
-uniresolver_driver_kilt_did_node=wss://full-nodes.kilt.io:9944
+uniresolver_driver_kilt_blockchain_node=wss://spiritnet.kilt.io
 
 uniresolver_driver_dns_dnsServers=
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ You should then be able to resolve identifiers locally using simple `curl` reque
 	curl -X GET http://localhost:8080/1.0/identifiers/did:ccp:ceNobbK6Me9F5zwyE3MKY88QZLw
 	curl -X GET http://localhost:8080/1.0/identifiers/did:work:2UUHQCd4psvkPLZGnWY33L
 	curl -X GET http://localhost:8080/1.0/identifiers/did:ont:AN5g6gz9EoQ3sCNu7514GEghZurrktCMiH
-	curl -X GET http://localhost:8080/1.0/identifiers/did:kilt:5CqJa4Ct7oMeMESzehTiN9fwYdGLd7tqeirRMpGDh2XxYYyx
+	curl -X GET http://localhost:8080/1.0/identifiers/did:kilt:4rNTX3ihuxyWkB7wG3oLgUWSBLa2gva1NBKJsBFm7jJZUYfc
 	curl -X GET http://localhost:8080/1.0/identifiers/did:evan:testcore:0x126E901F6F408f5E260d95c62E7c73D9B60fd734
 	curl -X GET http://localhost:8080/1.0/identifiers/did:factom:testnet:6aa7d4afe4932885b5b6e93accb5f4f6c14bd1827733e05e3324ae392c0b2764
 	curl -X GET http://localhost:8080/1.0/identifiers/did:mpg:7PGGnRdvKKFftSXU3Jw75Vk5npfg
@@ -102,7 +102,7 @@ Are you developing a DID method and Universal Resolver driver? Click [Driver Dev
 | [did-ccp](https://github.com/decentralized-identity/uni-resolver-driver-did-ccp/) | 0.1-SNAPSHOT | [0.1](https://did.baidu.com/did-spec/) | [hello2mao/driver-did-ccp](https://hub.docker.com/r/hello2mao/driver-did-ccp/) | Baidu Cloud
 | [did-work](https://github.com/decentralized-identity/uni-resolver-driver-did-work/) | 0.2  | [1.0](https://workday.github.io/work-did-method-spec/) | [didwork/work-did-driver](https://hub.docker.com/r/didwork/work-did-driver)| Workday Credentials
 | [did-ont](https://github.com/ontio/ontid-driver) | 0.1 | [1.0](https://github.com/ontio/ontology-DID/blob/master/docs/en/DID-ONT-method.md) |  [ontio/ontid-driver](https://hub.docker.com/r/ontio/ontid-driver) | Ontology ONT ID
-| [did-kilt](https://github.com/KILTprotocol/kilt-did-driver) | 1.2.1 | [1.0](https://github.com/KILTprotocol/kilt-did-driver/blob/master/DID%20Method%20Specification.md) | [kiltprotocol/kilt-did-driver](https://hub.docker.com/r/kiltprotocol/kilt-did-driver)| KILT Protocol (SSI credentials)
+| [did-kilt](https://github.com/KILTprotocol/kilt-did-driver) | 2.2.0 | [1.1](https://github.com/KILTprotocol/kilt-did-driver/blob/master/docs/did-spec/spec.md) | [kiltprotocol/kilt-did-driver](https://hub.docker.com/r/kiltprotocol/kilt-did-driver)| KILT Protocol
 | [did-evan](https://github.com/evannetwork/did-driver) | 0.1 | [0.9](https://github.com/evannetwork/evan.network-DID-method-specification/blob/master/evan_did_method_spec.md) | [evannetwork/evan-did-driver](https://hub.docker.com/r/evannetwork/evan-did-driver) | evan.network
 | [did-factom](https://github.com/Sphereon-Opensource/uni-resolver-driver-did-factom) | 0.2.0-SNAPSHOT | [1.0](https://github.com/bi-foundation/FIS/blob/feature/DID/FIS/DID.md) | [sphereon/uni-resolver-driver-did-factom](https://hub.docker.com/r/sphereon/uni-resolver-driver-did-factom) | Factom Protocol
 | [did-key](https://github.com/decentralized-identity/uni-resolver-driver-did-key) | 1.0.0 | [0.7](https://w3c-ccg.github.io/did-method-key/) | [universalresolver/driver-did-key](https://hub.docker.com/r/universalresolver/driver-did-key) | Public keys (in general)

--- a/config.json
+++ b/config.json
@@ -95,7 +95,7 @@
 		}, {
 			"pattern": "^(did:kilt:.+)$",
 			"url": "http://kilt-did-driver:8080/",
-			"testIdentifiers" : [ "did:kilt:5CqJa4Ct7oMeMESzehTiN9fwYdGLd7tqeirRMpGDh2XxYYyx" ]
+			"testIdentifiers" : [ "did:kilt:4rNTX3ihuxyWkB7wG3oLgUWSBLa2gva1NBKJsBFm7jJZUYfc", "did:kilt:light:004pqDzaWi3w7TzYzGnQDyrasK6UnyNnW6JQvWRrq6r8HzNNGy", "did:kilt:light:004pqDzaWi3w7TzYzGnQDyrasK6UnyNnW6JQvWRrq6r8HzNNGy:z14mMLbhZGB6YYU7ud2eFvUiHz3Mwo6UdttffCxB5s4hB3pxV2UgTQrgTyV6MZ8FAvqqKZQpxsJTFRYHzYhjzDUbxMtyxQtTrBu4F9YZx99AuEHuNSPCCd8RqpLeczkuDTGMP7eBDmmNbPbiXhKv5hb6ibYPCpZjUtjPBDqUQ1wXmBv3" ]
 		}, {
 			"pattern": "^(did:evan:.+)$",
 			"url": "http://evan-did-driver:8080/",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,9 +66,9 @@ services:
     ports:
       - "8093:8080"
   kilt-did-driver:
-    image: kiltprotocol/kilt-did-driver:1.3.0
+    image: kiltprotocol/kilt-did-driver:2.2.0
     environment:
-      uniresolver_driver_kilt_did_node: ${uniresolver_driver_kilt_did_node}
+      KILT_BLOCKCHAIN_NODE: ${uniresolver_driver_kilt_blockchain_node}
     ports:
       - "8094:8080"
   evan-did-driver:


### PR DESCRIPTION
Linked to https://github.com/decentralized-identity/universal-resolver/pull/266.

Update to the KILT driver to v2.2.0 and DID spec method v1.1.