### PR TITLE
Add RSA did:key

### DIFF
--- a/config.json
+++ b/config.json
@@ -181,7 +181,7 @@
 			"testIdentifiers": [ "did:meta:0000000000000000000000000000000000000000000000000000000000005e65" ]
 		},
 		{
-			"pattern": "^did:(?:tz:|pkh:|web:|key:(?:z6Mk|zQ3s|zDna)).+$",
+			"pattern": "^did:(?:tz:|pkh:|web:|key:(?:z6Mk|zQ3s|zDna|z.{200,})).+$",
 			"url": "http://driver-didkit:8080/identifiers/$1",
 			"testIdentifiers": [
 				"did:tz:tz1YwA1FwpgLtc1G8DKbbZ6e6PTb1dQMRn5x",
@@ -190,6 +190,7 @@
 				"did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH",
 				"did:key:zQ3shokFTS3brHcDQrn82RUDfCZESWL1ZdCEJwekUDPQiYBme",
 				"did:key:zDnaerDaTF5BXEavCrfRZEk316dpbLsfPDZ3WJ5hRTPFU2169",
+				"did:key:z4MXj1wBzi9jUstyPMS4jQqB6KdJaiatPkAtVtGc6bQEQEEsKTic4G7Rou3iBf9vPmT5dbkm9qsZsuVNjq8HCuW1w24nhBFGkRE4cd2Uf2tfrB3N7h4mnyPp1BF3ZttHTYv3DLUPi1zMdkULiow3M1GfXkoC6DoxDUm1jmN6GBj22SjVsr6dxezRVQc7aj9TxE7JLbMH1wh5X3kA58H3DFW8rnYMakFGbca5CB2Jf6CnGQZmL7o5uJAdTwXfy2iiiyPxXEGerMhHwhjTA1mKYobyk2CpeEcmvynADfNZ5MBvcCS7m3XkFCMNUYBS9NQ3fze6vMSUPsNa6GVYmKx2x6JrdEjCk3qRMMmyjnjCMfR4pXbRMZa3i",
 				"did:pkh:tz:tz2BFTyPeYRzxd5aiBchbXN3WCZhx7BqbMBq"
 			]
 		},


### PR DESCRIPTION
RSA test vectors were added to the `did:key` specification in https://github.com/w3c-ccg/did-method-key/pull/41.

DIDKit got support for RSA `did:key` via https://github.com/spruceid/ssi/pull/309.

This PR updates UR's config to try to use DIDKit for resolving RSA `did:key` DIDs. The 2048-bit test vector from the specification is added as a test identifier.

I did not find a way to match a RSA did:key with a regex for a key of arbitrary length - only for specific lengths (e.g. `z4MX` for 2048-bit, `z2W` for 3072-bit, `zgg` for 4096-bit - as seen in the specification [draft](https://w3c-ccg.github.io/did-method-key/#rsa)). So this PR matches based on length instead. The length of 200 or greater after the "z" should match a key with modulus of 1024-bits or longer. This is also longer than the other longest did:key seen so far, the uncompressed P-521 (which was removed in https://github.com/w3c-ccg/did-method-key/pull/36 in favor of the compressed one; DIDKit doesn't yet support P-521 in any case). JsonWebSignature2020 and JWS specifications recommend or require 2048-bit modulus for RSA, so this length minimum of 1024 should be compatible with practical usage.