### PR TITLE
fix(deps): update driver for did:ethr 2.3.0

### DIFF
--- a/config.json
+++ b/config.json
@@ -40,18 +40,14 @@
 			"testIdentifiers": [
 				"did:ethr:0x3b0BC51Ab9De1e5B7B6E34E5b960285805C41736",
 				"did:ethr:0x03fdd57adec3d438ea237fe46b33ee1e016eda6b585c3e27ea66686c2ea5358479",
-				"did:ethr:mainnet:0x3b0BC51Ab9De1e5B7B6E34E5b960285805C41736",
-				"did:ethr:mainnet:0x03fdd57adec3d438ea237fe46b33ee1e016eda6b585c3e27ea66686c2ea5358479",
 				"did:ethr:0x1:0x3b0BC51Ab9De1e5B7B6E34E5b960285805C41736",
 				"did:ethr:0x1:0x03fdd57adec3d438ea237fe46b33ee1e016eda6b585c3e27ea66686c2ea5358479",
-				"did:ethr:rinkeby:0x3b0BC51Ab9De1e5B7B6E34E5b960285805C41736",
 				"did:ethr:rinkeby:0x03fdd57adec3d438ea237fe46b33ee1e016eda6b585c3e27ea66686c2ea5358479",
-				"did:ethr:0x4:0x3b0BC51Ab9De1e5B7B6E34E5b960285805C41736",
 				"did:ethr:0x4:0x03fdd57adec3d438ea237fe46b33ee1e016eda6b585c3e27ea66686c2ea5358479",
-				"did:ethr:rsk:0x3b0BC51Ab9De1e5B7B6E34E5b960285805C41736",
 				"did:ethr:rsk:0x03fdd57adec3d438ea237fe46b33ee1e016eda6b585c3e27ea66686c2ea5358479",
-				"did:ethr:0x1e:0x3b0BC51Ab9De1e5B7B6E34E5b960285805C41736",
-				"did:ethr:0x1e:0x03fdd57adec3d438ea237fe46b33ee1e016eda6b585c3e27ea66686c2ea5358479"
+				"did:ethr:0x1e:0x03fdd57adec3d438ea237fe46b33ee1e016eda6b585c3e27ea66686c2ea5358479",
+				"did:ethr:ewc:0x03fdd57adec3d438ea237fe46b33ee1e016eda6b585c3e27ea66686c2ea5358479",
+				"did:ethr:volta:0x03fdd57adec3d438ea237fe46b33ee1e016eda6b585c3e27ea66686c2ea5358479"
 			]
 		}, {
 			"pattern": "^(did:eosio:.+)$",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
     ports:
       - "8082:8080"
   uni-resolver-driver-did-uport:
-    image: uport/uni-resolver-driver-did-uport:2.2.0
+    image: uport/uni-resolver-driver-did-uport:2.3.0
     ports:
       - "8083:8081"
   driver-did-stack:


### PR DESCRIPTION
This adds support and examples for `did:ethr:ewc:...` and `did:ethr:volta:...`

I also removed some redundant examples