### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,8 @@ services:
       uniresolver_driver_did_sov_libIndyPath: ${uniresolver_driver_did_sov_libIndyPath}
       uniresolver_driver_did_sov_poolConfigs: ${uniresolver_driver_did_sov_poolConfigs}
       uniresolver_driver_did_sov_poolVersions: ${uniresolver_driver_did_sov_poolVersions}
-      uniresolver_driver_did_sov_walletName: ${uniresolver_driver_did_sov_walletName}
+      uniresolver_driver_did_sov_walletNames: ${uniresolver_driver_did_sov_walletNames}
+      uniresolver_driver_did_sov_submitterDidSeeds: ${uniresolver_driver_did_sov_submitterDidSeeds}
     ports:
       - "8082:8080"
   uni-resolver-driver-did-uport:


### PR DESCRIPTION
Edit `did_sov_walletName` > `did_sov_walletNames`
- This should be a typo, `.env` and `docker-compose.yml` variables don't coincide so there is a warning when the resolver gets run, now it's ok

Add `uniresolver_driver_did_sov_submitterDidSeeds`
- This is because in `.env` the variable is set, but it's not used in `docker-compose.yml`, now yes