### PR TITLE
Add did:kscirc driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ You should then be able to resolve identifiers locally using simple `curl` reque
 	curl -X GET http://localhost:8080/1.0/identifiers/did:ala:quor:redT:ec27f358fd0d11d8934ceb51305622ae79b6ad15
 	curl -X GET http://localhost:8080/1.0/identifiers/did:cheqd:mainnet:zF7rhDBfUt9d1gJPjx7s1JXfUY7oVWkY
 	curl -X GET http://localhost:8080/1.0/identifiers/did:com:1l6zglh8pvcrjtahsvds2qmfpn0hv83vn8f9cf3
+	curl -X GET http://localhost:8080/1.0/identifiers/did:kscirc:k17bdBuzB3u143mFXZNq3jRHNgMgdFTpUi7qF5Ee3Af3RqPWVbq
 
 
 You can also use an "Accept" header to request the DID document in a specific representation, e.g.:
@@ -142,6 +143,8 @@ Are you developing a DID method and Universal Resolver driver? Click [Driver Dev
 | [did-com](https://github.com/commercionetwork/uni-resolver-driver-did-com/) | 1.0.0 | [1.0](https://docs.commercio.network/modules/did/) | [ghcr.io/commercionetwork/uni-resolver-driver-did-com](https://github.com/commercionetwork/uni-resolver-driver-did-com/pkgs/container/uni-resolver-driver-did-com) | Commercio public ledger |
 | [did-dyne](https://github.com/dyne/W3C-DID) | 0.1 | [1.0](https://dyne.github.io/W3C-DID/#/) | [dyne/w3c-did-driver](https://hub.docker.com/r/dyne/w3c-did-driver/) | Dyne.org Decentralized Identifiers |
 | [did-jwk](https://github.com/transmute-industries/restricted-resolver) | 0.1 | [1.0](https://github.com/quartzjer/did-jwk/blob/main/spec.md) | [transmute/restricted-resolver](https://hub.docker.com/repository/docker/transmute/restricted-resolver) | DID Json Web Key |
+| [did-kscirc]() | 0.1 | [1.0](https://tangy-gallium-b9b.notion.site/DID-Method-Specification-KSChain-7a77664f1eae47769692f4ff2d029fe0) | [k4security/kschain-resolver](https://hub.docker.com/r/k4security/kschain-resolver) | KSChain blockchain |
+
 
 ## More Information
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ You should then be able to resolve identifiers locally using simple `curl` reque
 	curl -X GET http://localhost:8080/1.0/identifiers/did:ala:quor:redT:ec27f358fd0d11d8934ceb51305622ae79b6ad15
 	curl -X GET http://localhost:8080/1.0/identifiers/did:cheqd:mainnet:zF7rhDBfUt9d1gJPjx7s1JXfUY7oVWkY
 	curl -X GET http://localhost:8080/1.0/identifiers/did:com:1l6zglh8pvcrjtahsvds2qmfpn0hv83vn8f9cf3
-	curl -X GET http://localhost:8080/1.0/identifiers/did:kscirc:k17bdBuzB3u143mFXZNq3jRHNgMgdFTpUi7qF5Ee3Af3RqPWVbq
+	curl -X GET http://localhost:8080/1.0/identifiers/did:kscirc:k12NqvVM9BX6AaMjPK1hUTUkKBWPBAUXAszTxdx7jDZPv4iqCZ1D
 
 
 You can also use an "Accept" header to request the DID document in a specific representation, e.g.:
@@ -143,7 +143,7 @@ Are you developing a DID method and Universal Resolver driver? Click [Driver Dev
 | [did-com](https://github.com/commercionetwork/uni-resolver-driver-did-com/) | 1.0.0 | [1.0](https://docs.commercio.network/modules/did/) | [ghcr.io/commercionetwork/uni-resolver-driver-did-com](https://github.com/commercionetwork/uni-resolver-driver-did-com/pkgs/container/uni-resolver-driver-did-com) | Commercio public ledger |
 | [did-dyne](https://github.com/dyne/W3C-DID) | 0.1 | [1.0](https://dyne.github.io/W3C-DID/#/) | [dyne/w3c-did-driver](https://hub.docker.com/r/dyne/w3c-did-driver/) | Dyne.org Decentralized Identifiers |
 | [did-jwk](https://github.com/transmute-industries/restricted-resolver) | 0.1 | [1.0](https://github.com/quartzjer/did-jwk/blob/main/spec.md) | [transmute/restricted-resolver](https://hub.docker.com/repository/docker/transmute/restricted-resolver) | DID Json Web Key |
-| [did-kscirc]() | 0.1 | [1.0](https://tangy-gallium-b9b.notion.site/DID-Method-Specification-KSChain-7a77664f1eae47769692f4ff2d029fe0) | [k4security/kschain-resolver](https://hub.docker.com/r/k4security/kschain-resolver) | KSChain blockchain |
+| [did-kscirc](https://github.com/sujiny-tech/kschain-resolver) | 0.1 | [1.0](https://tangy-gallium-b9b.notion.site/DID-Method-Specification-KSChain-7a77664f1eae47769692f4ff2d029fe0) | [k4security/kschain-resolver](https://hub.docker.com/r/k4security/kschain-resolver) | KSChain blockchain |
 
 
 ## More Information

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Are you developing a DID method and Universal Resolver driver? Click [Driver Dev
 | [did-com](https://github.com/commercionetwork/uni-resolver-driver-did-com/) | 1.0.0 | [1.0](https://docs.commercio.network/modules/did/) | [ghcr.io/commercionetwork/uni-resolver-driver-did-com](https://github.com/commercionetwork/uni-resolver-driver-did-com/pkgs/container/uni-resolver-driver-did-com) | Commercio public ledger |
 | [did-dyne](https://github.com/dyne/W3C-DID) | 0.1 | [1.0](https://dyne.github.io/W3C-DID/#/) | [dyne/w3c-did-driver](https://hub.docker.com/r/dyne/w3c-did-driver/) | Dyne.org Decentralized Identifiers |
 | [did-jwk](https://github.com/transmute-industries/restricted-resolver) | 0.1 | [1.0](https://github.com/quartzjer/did-jwk/blob/main/spec.md) | [transmute/restricted-resolver](https://hub.docker.com/repository/docker/transmute/restricted-resolver) | DID Json Web Key |
-| [did-kscirc](https://github.com/sujiny-tech/kschain-resolver) | 0.1 | [1.0](https://tangy-gallium-b9b.notion.site/DID-Method-Specification-KSChain-7a77664f1eae47769692f4ff2d029fe0) | [k4security/kschain-resolver](https://hub.docker.com/r/k4security/kschain-resolver) | KSChain blockchain |
+| [did-kscirc](https://github.com/sujiny-tech/kschain-resolver) | 0.1 | [1.0](https://tangy-gallium-b9b.notion.site/DID-Method-Specification-KSChain-7a77664f1eae47769692f4ff2d029fe0) | [k4security/kschain-resolver](https://hub.docker.com/r/k4security/kschain-resolver) | KSChain blockchain  |
 
 
 ## More Information

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -216,3 +216,7 @@ services:
     image: transmute/restricted-resolver:latest
     ports:
       - "8134:8080"
+  did-kscirc-driver:
+    image: k4security/kschain-resolver:latest
+    ports: 
+      - "8135:8080"

--- a/uni-resolver-web/src/main/resources/application.yml
+++ b/uni-resolver-web/src/main/resources/application.yml
@@ -257,9 +257,9 @@ uniresolver:
         - did:jwk:eyJraWQiOiJ1cm46aWV0ZjpwYXJhbXM6b2F1dGg6andrLXRodW1icHJpbnQ6c2hhLTI1NjpGZk1iek9qTW1RNGVmVDZrdndUSUpqZWxUcWpsMHhqRUlXUTJxb2JzUk1NIiwia3R5IjoiT0tQIiwiY3J2IjoiRWQyNTUxOSIsImFsZyI6IkVkRFNBIiwieCI6IkFOUmpIX3p4Y0tCeHNqUlBVdHpSYnA3RlNWTEtKWFE5QVBYOU1QMWo3azQifQ
         - did:jwk:eyJraWQiOiJ1cm46aWV0ZjpwYXJhbXM6b2F1dGg6andrLXRodW1icHJpbnQ6c2hhLTI1Njpnc0w0VTRxX1J6VFhRckpwQUNnZGkwb1lCdUV1QjNZNWZFanhDd1NPUFlBIiwia3R5IjoiRUMiLCJjcnYiOiJQLTM4NCIsImFsZyI6IkVTMzg0IiwieCI6ImEtRWV5T2hlRUNWcDJqRkdVRTNqR0RCNlAzVV80S0lyZHRzTU9RQXFQN0NBMlVvV3NERG1nOWdJUVhiOEthd0ciLCJ5Ijoib3cxWDJ6VFVRaG12elY4NnpHdGhKc0xLeDE2MmhmSmxmN1p0OTFYUnZBTzRScE4zR2RGaVl3Tmc0NXJWUmlUcSJ9
     - pattern: "^(did:kscirc:.+)$"
-      url: http://kschain-resolver:8080/
+      url: http://did-kscirc-driver:8080/1.0/identifiers/$1
       testIdentifiers:
-        - did:kscirc:k17bdBuzB3u143mFXZNq3jRHNgMgdFTpUi7qF5Ee3Af3RqPWVbq
-        - did:kscirc:k185YtUkv5w5sAvrB7M6CP9CP4Szjd9h5V71euoizwh4gp4XCH5
+        - did:kscirc:k12NqvVM9BX6AaMjPK1hUTUkKBWPBAUXAszTxdx7jDZPv4iqCZ1D
+        - did:kscirc:k17qQYbApdfTdxsrS77k3sbFmJCWfJf7QrvZSfMaAmq6MWpbeGs
 
 

--- a/uni-resolver-web/src/main/resources/application.yml
+++ b/uni-resolver-web/src/main/resources/application.yml
@@ -256,6 +256,10 @@ uniresolver:
       testIdentifiers:
         - did:jwk:eyJraWQiOiJ1cm46aWV0ZjpwYXJhbXM6b2F1dGg6andrLXRodW1icHJpbnQ6c2hhLTI1NjpGZk1iek9qTW1RNGVmVDZrdndUSUpqZWxUcWpsMHhqRUlXUTJxb2JzUk1NIiwia3R5IjoiT0tQIiwiY3J2IjoiRWQyNTUxOSIsImFsZyI6IkVkRFNBIiwieCI6IkFOUmpIX3p4Y0tCeHNqUlBVdHpSYnA3RlNWTEtKWFE5QVBYOU1QMWo3azQifQ
         - did:jwk:eyJraWQiOiJ1cm46aWV0ZjpwYXJhbXM6b2F1dGg6andrLXRodW1icHJpbnQ6c2hhLTI1Njpnc0w0VTRxX1J6VFhRckpwQUNnZGkwb1lCdUV1QjNZNWZFanhDd1NPUFlBIiwia3R5IjoiRUMiLCJjcnYiOiJQLTM4NCIsImFsZyI6IkVTMzg0IiwieCI6ImEtRWV5T2hlRUNWcDJqRkdVRTNqR0RCNlAzVV80S0lyZHRzTU9RQXFQN0NBMlVvV3NERG1nOWdJUVhiOEthd0ciLCJ5Ijoib3cxWDJ6VFVRaG12elY4NnpHdGhKc0xLeDE2MmhmSmxmN1p0OTFYUnZBTzRScE4zR2RGaVl3Tmc0NXJWUmlUcSJ9
-    
+    - pattern: "^(did:kscirc:.+)$"
+      url: http://kschain-resolver:8080/
+      testIdentifiers:
+        - did:kscirc:k17bdBuzB3u143mFXZNq3jRHNgMgdFTpUi7qF5Ee3Af3RqPWVbq
+        - did:kscirc:k185YtUkv5w5sAvrB7M6CP9CP4Szjd9h5V71euoizwh4gp4XCH5
 
 


### PR DESCRIPTION
Adding did resolver for did:kscirc (KSChain).
It registered in DID Specification Registries: [w3c/did-spec-registres#459](https://github.com/w3c/did-spec-registries/pull/459).


Sujin Lee
sujiny2222@k4-security.com
http://www.k4-security.com/