### PR TITLE
Add did:iscc driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ You should then be able to resolve identifiers locally using simple `curl` reque
 	curl -X GET http://localhost:8080/1.0/identifiers/did:cheqd:mainnet:zF7rhDBfUt9d1gJPjx7s1JXfUY7oVWkY
 	curl -X GET http://localhost:8080/1.0/identifiers/did:com:1l6zglh8pvcrjtahsvds2qmfpn0hv83vn8f9cf3
 	curl -X GET http://localhost:8080/1.0/identifiers/did:kscirc:k12NqvVM9BX6AaMjPK1hUTUkKBWPBAUXAszTxdx7jDZPv4iqCZ1D
+	curl -X GET http://localhost:8080/1.0/identifiers/did:iscc:miagwptv4j2z57ci
 
 
 You can also use an "Accept" header to request the DID document in a specific representation, e.g.:
@@ -144,7 +145,7 @@ Are you developing a DID method and Universal Resolver driver? Click [Driver Dev
 | [did-dyne](https://github.com/dyne/W3C-DID) | 0.1 | [1.0](https://dyne.github.io/W3C-DID/#/) | [dyne/w3c-did-driver](https://hub.docker.com/r/dyne/w3c-did-driver/) | Dyne.org Decentralized Identifiers |
 | [did-jwk](https://github.com/transmute-industries/restricted-resolver) | 0.1 | [1.0](https://github.com/quartzjer/did-jwk/blob/main/spec.md) | [transmute/restricted-resolver](https://hub.docker.com/repository/docker/transmute/restricted-resolver) | DID Json Web Key |
 | [did-kscirc](https://github.com/sujiny-tech/kschain-resolver) | 0.1 | [1.0](https://tangy-gallium-b9b.notion.site/DID-Method-Specification-KSChain-7a77664f1eae47769692f4ff2d029fe0) | [k4security/kschain-resolver](https://hub.docker.com/r/k4security/kschain-resolver) | KSChain blockchain  |
-
+| [did-iscc](https://github.com/iscc/iscc-did-driver) | 0.1.0 | [0.1](https://ieps.iscc.codes/iep-0015/) | [ghcr.io/iscc/iscc-did-driver](https://github.com/iscc/iscc-did-driver/pkgs/container/iscc-did-driver) | International Standard Content Code - [ISCC](https://iscc.codes) | 
 
 ## More Information
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -218,5 +218,9 @@ services:
       - "8134:8080"
   did-kscirc-driver:
     image: k4security/kschain-resolver:latest
-    ports: 
+    ports:
       - "8135:8080"
+  driver-did-iscc:
+    image: ghcr.io/iscc/iscc-did-driver:main
+    ports:
+      - "8136:8080"

--- a/uni-resolver-web/src/main/resources/application.yml
+++ b/uni-resolver-web/src/main/resources/application.yml
@@ -261,5 +261,7 @@ uniresolver:
       testIdentifiers:
         - did:kscirc:k12NqvVM9BX6AaMjPK1hUTUkKBWPBAUXAszTxdx7jDZPv4iqCZ1D
         - did:kscirc:k17qQYbApdfTdxsrS77k3sbFmJCWfJf7QrvZSfMaAmq6MWpbeGs
-
-
+    - pattern: "^(did:iscc:.+)$"
+      url: http://driver-did-iscc:8080/
+      testIdentifiers:
+        - did:iscc:miagwptv4j2z57ci


### PR DESCRIPTION
Driver contribution for `did:iscc`. See:

- [ISCC DID Method Specification](https://ieps.iscc.codes/iep-0015)
- [ISCC DID Driver Implementation](https://github.com/iscc/iscc-did-driver)
- [Public Resolver Instance](https://did.iscc.id)
- [DID Spec Registration](https://github.com/w3c/did-spec-registries/pull/465)