### PR TITLE
add DID PLC (uni-resolver-driver-did-plc)

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ You should then be able to resolve identifiers locally using simple `curl` reque
 	curl -X GET http://localhost:8080/1.0/identifiers/did:polygonid:polygon:mumbai:2qDj9EDytmvtQP1or3FxykXGEaqSA1ss479MYHDMJc
 	curl -X GET http://localhost:8080/1.0/identifiers/did:pdc:8801:0xf47b66bc0d9b7c73f9ff27bf1f49a2b69dc167fc
 	curl -X GET http://localhost:8080/1.0/identifiers/did:tys:4B4AbVzzcJSnCZsdX4VaKyQgHRnC
+	curl -X GET http://localhost:8080/1.0/identifiers/did:plc:yk4dd2qkboz2yv6tpubpc6co
 
 You can also use an "Accept" header to request the DID document in a specific representation, e.g.:
 
@@ -164,6 +165,8 @@ Are you developing a DID method and Universal Resolver driver? Click [Driver Dev
 | [did-polygonid](https://github.com/0xPolygonID/driver-did-polygonid/blob/main/README.md)                        | 0.0.1          | [1.0.0](https://github.com/0xPolygonID/did-polygonid/blob/main/README.md)                                       | [polygonid/driver-did-polygonid](https://hub.docker.com/r/polygonid/driver-did-polygonid)                                                              | PolygonID DID                                                                        |
 | [did-pdc](https://github.com/pdc-community/uni-resolver-driver-did-pdc/blob/master/README.md)         | 0.0.1          | (missing)                                                                                                         | [w744219971/driver-did-pdc](https://hub.docker.com/r/w744219971/driver-did-pdc)                                                                                    | PDC DID                                                                             |
 | [did-tys](https://github.com/itpeople-cy/tys-did-driver/blob/master/README.md)         | 1.0          | 1.0                                                                                                         | [itpeoplecorp/tys-did-driver](https://hub.docker.com/r/itpeoplecorp/tys-did-driver)                                                                                    | TYS DID                         
+| [did-plc](https://plc.directory)                                                                      | 0.0.1          | [dev](https://github.com/bluesky-social/did-method-plc/blob/main/README.md)      | [bnewbold/uni-resolver-driver-did-plc](https://hub.docker.com/r/bnewbold/uni-resolver-driver-did-plc)                                                                                    | PLC DID                                                                                        |
+
 ## More Information
 
  * [Driver Development](/docs/driver-development.md)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -258,3 +258,7 @@ services:
     image: itpeoplecorp/tys-did-driver:latest
     ports:
       - "8143:8080"
+  driver-did-plc:
+    image: bnewbold/uni-resolver-driver-did-plc:latest
+    ports:
+      - "8144:8000"

--- a/uni-resolver-web/src/main/resources/application.yml
+++ b/uni-resolver-web/src/main/resources/application.yml
@@ -305,3 +305,8 @@ uniresolver:
       url: http://driver-did-tys:8080/
       testIdentifiers:
         - did:tys:4B4AbVzzcJSnCZsdX4VaKyQgHRnC
+    - pattern: "^(did:plc:.+)$"
+      url: http://driver-did-plc:8000/
+      testIdentifiers:
+        - did:plc:yk4dd2qkboz2yv6tpubpc6co
+        - did:plc:44ybard66vv44zksje25o7dz


### PR DESCRIPTION
This is a very simple driver, in that it just proxies through to an external service. We may simple implement the `/1.0/identifiers/<did>` route on our main server in the future to remove the need for a docker image.

Followed the directions at https://github.com/decentralized-identity/universal-resolver/blob/main/docs/driver-development.md

Did not do a full docker-compose test of the (many!) combined images locally.