### PR TITLE
DID Driver URL parameterization

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,73 @@ services:
     image: universalresolver/uni-resolver-web:latest
     ports:
       - "8080:8080"
+    environment:
+      # Override default driver URLs if they are set in .env variables, otherwise
+      # don't define the variables and let resolver-web container use its default
+      # set in application.yml.
+      # See https://docs.docker.com/compose/compose-file/05-services/#environment
+      uniresolver_web_driver_url_did_btcr:
+      uniresolver_web_driver_url_did_sov:
+      uniresolver_web_driver_url_did_indy:
+      uniresolver_web_driver_url_did_v1_nym:
+      uniresolver_web_driver_url_did_v1_test_nym:
+      uniresolver_web_driver_url_did_stack:
+      uniresolver_web_driver_url_did_web:
+      uniresolver_web_driver_url_did_ethr:
+      uniresolver_web_driver_url_did_ens:
+      uniresolver_web_driver_url_did_peer:
+      uniresolver_web_driver_url_did_eosio:
+      uniresolver_web_driver_url_did_jolo:
+      uniresolver_web_driver_url_did_hcr:
+      uniresolver_web_driver_url_did_elem_ropsten:
+      uniresolver_web_driver_url_did_github:
+      uniresolver_web_driver_url_did_ccp:
+      uniresolver_web_driver_url_did_ont:
+      uniresolver_web_driver_url_did_kilt:
+      uniresolver_web_driver_url_did_factom:
+      uniresolver_web_driver_url_did_io:
+      uniresolver_web_driver_url_did_bba:
+      uniresolver_web_driver_url_did_schema:
+      uniresolver_web_driver_url_did_ion:
+      uniresolver_web_driver_url_did_ace:
+      uniresolver_web_driver_url_did_gatc:
+      uniresolver_web_driver_url_did_icon:
+      uniresolver_web_driver_url_did_vaa:
+      uniresolver_web_driver_url_did_unisot:
+      uniresolver_web_driver_url_did_sol:
+      uniresolver_web_driver_url_did_lit:
+      uniresolver_web_driver_url_did_ebsi:
+      uniresolver_web_driver_url_did_emtrust:
+      uniresolver_web_driver_url_did_meta:
+      uniresolver_web_driver_url_did_kit:
+      uniresolver_web_driver_url_did_key:
+      uniresolver_web_driver_url_did_orb:
+      uniresolver_web_driver_url_did_oyd:
+      uniresolver_web_driver_url_did_moncon:
+      uniresolver_web_driver_url_did_dock:
+      uniresolver_web_driver_url_did_mydata:
+      uniresolver_web_driver_url_did_dns:
+      uniresolver_web_driver_url_did_everscale:
+      uniresolver_web_driver_url_did_ala_quor_redt:
+      uniresolver_web_driver_url_did_cheqd:
+      uniresolver_web_driver_url_did_com:
+      uniresolver_web_driver_url_did_dyne:
+      uniresolver_web_driver_url_did_jwk:
+      uniresolver_web_driver_url_did_kscirc:
+      uniresolver_web_driver_url_did_iscc:
+      uniresolver_web_driver_url_did_ev:
+      uniresolver_web_driver_url_did_iid:
+      uniresolver_web_driver_url_did_evan:
+      uniresolver_web_driver_url_did_bid:
+      uniresolver_web_driver_url_did_polygonid:
+      uniresolver_web_driver_url_did_pdc:
+      uniresolver_web_driver_url_did_tys:
+      uniresolver_web_driver_url_did_plc:
+      uniresolver_web_driver_url_did_evrc:
+      uniresolver_web_driver_url_did_kerri:
+      uniresolver_web_driver_url_did_webs:
+      uniresolver_web_driver_url_did_content:
+
   driver-did-btcr:
     image: universalresolver/driver-did-btcr:latest
     environment:

--- a/docs/driver-development.md
+++ b/docs/driver-development.md
@@ -43,9 +43,10 @@ Create a PR that edits the following files in the Universal Resolver root direct
   * image - your Docker image name
   * ports - incremented port number exposed by your Docker image
   * environment - optional environment variables supported by your Docker image
-- [`application.yml`](https://github.com/decentralized-identity/universal-resolver/blob/main/uni-resolver-web/src/main/resources/application.yml) (add  your driver)
+  * uni-resolver-web service - add an `environment` variable for your drivers URL into the uni-resolver-web service definition at the top of this file. This can be used to inject the driver URL at runtime and override the default hard coded value in the application.yml. The variable name should follow the convention of `uniresolver_web_driver_url_did_<your-did-method-identifier>` to avoid conflicts.
+* [`application.yml`](https://github.com/decentralized-identity/universal-resolver/blob/main/uni-resolver-web/src/main/resources/application.yml) (add your driver)
   * pattern - regular expression for matching your DID method
-  * url - endpoint of your Docker image or external resolver endpoint
+  * url - this should be in the format of a [spring property placeholder](https://docs.spring.io/spring-boot/docs/current/reference/html/features.html#features.external-config.files.property-placeholders) to allow possible injection of the URL at runtime. The placeholder should use the environment variable specified in the `docker-compose.yml` for your driver and provide a default endpoint of your Docker compose service name or external resolver endpoint. The general spring placeholder format to use is `${uniresolver_web_driver_url_did_<your-did-method-identifier>:<default-static-url>}`.
   * testIdentifiers - list of example DIDs that your driver can resolve
 - [`.env`](https://github.com/decentralized-identity/universal-resolver/blob/main/.env)
   * list environment variables (if any) with default values

--- a/uni-resolver-web/src/main/resources/application.yml
+++ b/uni-resolver-web/src/main/resources/application.yml
@@ -13,14 +13,14 @@ spring:
 uniresolver:
   drivers:
     - pattern: "^(did:btcr:.+)$"
-      url: http://driver-did-btcr:8080/
+      url: ${uniresolver_web_driver_url_did_btcr:http://driver-did-btcr:8080/}
       propertiesEndpoint: 'true'
       testIdentifiers:
         - did:btcr:xz35-jznz-q9yu-ply
         - did:btcr:xkrn-xz7q-qsye-28p
         - did:btcr:x705-jznz-q3nl-srs
     - pattern: "^(did:sov:(?:(?:\\w[-\\w]*(?::\\w[-\\w]*)*):)?(?:[1-9A-HJ-NP-Za-km-z]{21,22}))$"
-      url: http://driver-did-sov:8080/
+      url: ${uniresolver_web_driver_url_did_sov:http://driver-did-sov:8080/}
       propertiesEndpoint: 'true'
       testIdentifiers:
         - did:sov:WRfXPg8dantKVubE3HX8pw
@@ -30,7 +30,7 @@ uniresolver:
         - did:sov:idunion:test:BDrEcHc8Tb4Lb2VyQZWEDE
         - did:sov:indicio:demo:KKyAeG7woJMV6MhhAREVKp
     - pattern: "^(did:indy:.+)$"
-      url: http://driver-did-indy:8080/
+      url: ${uniresolver_web_driver_url_did_indy:http://driver-did-indy:8080/}
       propertiesEndpoint: 'true'
       testIdentifiers:
         - did:indy:sovrin:WRfXPg8dantKVubE3HX8pw
@@ -42,30 +42,30 @@ uniresolver:
         - did:indy:nxd:LLDnZr8iaYM3F77pUWXnVX
         - did:indy:findy:test:KMSWjAnqdwgLRc5yZBygcA
     - pattern: "^(did:v1:nym:.+)$"
-      url: http://uni-resolver-did-v1-driver:8080/
+      url: ${uniresolver_web_driver_url_did_v1_nym:http://uni-resolver-did-v1-driver:8080/}
       propertiesEndpoint: 'true'
       testIdentifiers:
         - did:v1:nym:z6Mkmpe2DyE4NsDiAb58d75hpi1BjqbH6wYMschUkjWDEEuR
     - pattern: "^(did:v1:test:nym:.+)$"
-      url: http://uni-resolver-did-v1-driver:8080/
+      url: ${uniresolver_web_driver_url_did_v1_test_nym:http://uni-resolver-did-v1-driver:8080/}
       propertiesEndpoint: 'true'
       testIdentifiers:
         - did:v1:test:nym:z6MkgF4uJbLMoUin2uKaBf4Jb1F7SHzuALE8Ldq8FPPpHE9t
         - did:v1:test:nym:z6MkmWLiAt5FtfwgFJwMDGS1GiFn1KpUXsd7bn1v2hLyXvud
     - pattern: "^(did:stack:.+)$"
-      url: http://driver-did-stack:8080/
+      url: ${uniresolver_web_driver_url_did_stack:http://driver-did-stack:8080/}
       propertiesEndpoint: 'true'
       testIdentifiers:
         - did:stack:v0:16EMaNw3pkn3v6f2BgnSSs53zAKH4Q8YJg-0
     - pattern: "^(did:web:.+)$"
-      url: http://uni-resolver-driver-did-uport:8081/
+      url: ${uniresolver_web_driver_url_did_web:http://uni-resolver-driver-did-uport:8081/}
       testIdentifiers:
         - did:web:did.actor:alice
         - did:web:did.actor:bob
         - did:web:did.actor:carol
         - did:web:did.actor:mike
     - pattern: "^(did:ethr:.+)$"
-      url: http://uni-resolver-driver-did-uport:8081/
+      url: ${uniresolver_web_driver_url_did_ethr:http://uni-resolver-driver-did-uport:8081/}
       testIdentifiers:
         - did:ethr:0x3b0BC51Ab9De1e5B7B6E34E5b960285805C41736
         - did:ethr:0x03fdd57adec3d438ea237fe46b33ee1e016eda6b585c3e27ea66686c2ea5358479
@@ -74,119 +74,119 @@ uniresolver:
         - did:ethr:goerli:0x03fdd57adec3d438ea237fe46b33ee1e016eda6b585c3e27ea66686c2ea5358479
         - did:ethr:0x5:0x03fdd57adec3d438ea237fe46b33ee1e016eda6b585c3e27ea66686c2ea5358479
     - pattern: "^(did:ens:.+)$"
-      url: http://uni-resolver-driver-did-uport:8081/
+      url: ${uniresolver_web_driver_url_did_ens:http://uni-resolver-driver-did-uport:8081/}
       testIdentifiers:
         - did:ens:vitalik.eth
         - did:ens:goerli:whatever.eth
     - pattern: "^(did:peer:.+)$"
-      url: http://uni-resolver-driver-did-uport:8081/
+      url: ${uniresolver_web_driver_url_did_peer:http://uni-resolver-driver-did-uport:8081/}
       testIdentifiers:
         - did:peer:2.Ez6LSghwSE437wnDE1pt3X6hVDUQzSjsHzinpX3XFvMjRAm7y.Vz6Mkhh1e5CEYYq6JBUcTZ6Cp2ranCWRrv7Yax3Le4N59R6dd.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9hbGljZS5kaWQuZm1ncC5hcHAvIiwiciI6W10sImEiOlsiZGlkY29tbS92MiJdfQ
         - did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDEiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MSJdLCJhIjpbImRpZGNvbW0vdjIiLCJkaWRjb21tL2FpcDI7ZW52PXJmYzU4NyJdfQ
     - pattern: "^(did:eosio:.+)$"
-      url: http://eosio-driver:8080/
+      url: ${uniresolver_web_driver_url_did_eosio:http://eosio-driver:8080/}
       testIdentifiers:
         - did:eosio:eos:eoscanadacom
         - did:eosio:4667b205c6838ef70ff7988f6e8257e8be0e1284a2f59699054a018f743b1d11:caleosblocks
     - pattern: "^(did:jolo:.+)$"
-      url: http://jolocom-did-driver:8080/
+      url: ${uniresolver_web_driver_url_did_jolo:http://jolocom-did-driver:8080/}
       testIdentifiers:
         - did:jolo:e76fb4b4900e43891f613066b9afca366c6d22f7d87fc9f78a91515be24dfb21
     - pattern: "^(did:hcr:.+)$"
-      url: http://hacera-did-driver:8080/
+      url: ${uniresolver_web_driver_url_did_hcr:http://hacera-did-driver:8080/}
       testIdentifiers:
         - did:hcr:0f674e7e-4b49-4898-85f6-96176c1e30de
     - pattern: "^(did:elem:ropsten:.+)$"
-      url: https://ropsten.element.transmute.industries/api/1.0/identifiers/$1
+      url: ${uniresolver_web_driver_url_did_elem_ropsten:https://ropsten.element.transmute.industries/api/1.0/identifiers/$1}
       testIdentifiers:
         - did:elem:ropsten:EiCtwD11AV9e1oISQRHnMJsBC3OBdYDmx8xeKeASrKaw6A
     - pattern: "^(did:github:.+)$"
-      url: https://github-did.com/api/v1/did/$1
+      url: ${uniresolver_web_driver_url_did_github:https://github-did.com/api/v1/did/$1}
       testIdentifiers:
         - did:github:gjgd
     - pattern: "^(did:ccp:.+)$"
-      url: http://driver-did-ccp:8080/
+      url: ${uniresolver_web_driver_url_did_ccp:http://driver-did-ccp:8080/}
       testIdentifiers:
         - did:ccp:ceNobbK6Me9F5zwyE3MKY88QZLw
         - did:ccp:3CzQLF3qfFVQ1CjGVzVRZaFXrjAd
     - pattern: "^(did:ont:.+)$"
-      url: http://ontid-driver:8080/
+      url: ${uniresolver_web_driver_url_did_ont:http://ontid-driver:8080/}
       testIdentifiers:
         - did:ont:AN5g6gz9EoQ3sCNu7514GEghZurrktCMiH
     - pattern: "^(did:kilt:.+)$"
-      url: http://kilt-did-driver:8080/
+      url: ${uniresolver_web_driver_url_did_kilt:http://kilt-did-driver:8080/}
       testIdentifiers:
         - did:kilt:4rNTX3ihuxyWkB7wG3oLgUWSBLa2gva1NBKJsBFm7jJZUYfc
         - did:kilt:light:004pqDzaWi3w7TzYzGnQDyrasK6UnyNnW6JQvWRrq6r8HzNNGy
         - did:kilt:light:004pqDzaWi3w7TzYzGnQDyrasK6UnyNnW6JQvWRrq6r8HzNNGy:z15dZSRuzEPTFnBErPxqJie4CmmQH1gYKSQYxmwW5Qhgz5Sr7EYJA3J65KoC5YbgF3NGoBsTY2v6zwj1uDnZzgXzLy8R72Fhjmp8ujY81y2AJc8uQ6s2pVbAMZ6bnvaZ3GVe8bMjY5MiKFySS27qRi
     - pattern: "^(did:factom:.+)$"
-      url: http://uni-resolver-driver-did-factom:8080/
+      url: ${uniresolver_web_driver_url_did_factom:http://uni-resolver-driver-did-factom:8080/}
       testIdentifiers:
         - did:factom:testnet:6aa7d4afe4932885b5b6e93accb5f4f6c14bd1827733e05e3324ae392c0b2764
         - did:factom:testnet:c2d5aa15943c93db313f140e7ed87ec9891d02acbde748932db583aa3080af08
     - pattern: "^(did:io:.+)$"
-      url: http://uni-resolver-driver-did-io:8080/
+      url: ${uniresolver_web_driver_url_did_io:http://uni-resolver-driver-did-io:8080/}
       testIdentifiers:
         - did:io:0x476c81C27036D05cB5ebfe30ae58C23351a61C4A
     - pattern: "^(did:bba:.+)$"
-      url: http://bba-did-driver:8080/
+      url: ${uniresolver_web_driver_url_did_bba:http://bba-did-driver:8080/}
       testIdentifiers:
         - did:bba:t:45e6df15dc0a7d91dcccd24fda3b52c3983a214fb0eed0938321c11ec99403cf
         - did:bba:47ef0798566073ea302b8178943aaa83f227614d6f36a4d2bcd92993bbed6044
     - pattern: "^(did:schema:.+)$"
-      url: http://schema-registry-did-resolver:8080/
+      url: ${uniresolver_web_driver_url_did_schema:http://schema-registry-did-resolver:8080/}
       testIdentifiers:
         - did:schema:public-ipfs:json-schema:Qma2beXKwZeiUXcaRaQKwbBV1TqyiJnsMTYExUTdQue43J
         - did:schema:evan-ipfs:json-schema:Qma2beXKwZeiUXcaRaQKwbBV1TqyiJnsMTYExUTdQue43J
     - pattern: "^(did:ion:(?!test).+)$"
-      url: http://driver-did-ion:8080/
+      url: ${uniresolver_web_driver_url_did_ion:http://driver-did-ion:8080/}
       testIdentifiers:
         - did:ion:EiClkZMDxPKqC9c-umQfTkR8vvZ9JPhl_xLDI9Nfk38w5w
     - pattern: "^(did:ace:.+)$"
-      url: http://ace-did-driver:8080/
+      url: ${uniresolver_web_driver_url_did_ace:http://ace-did-driver:8080/}
       testIdentifiers:
         - did:ace:0xf81c16a78b257c10fddf87ed4324d433317169a005ddf36a3a1ba937ba9788e3
     - pattern: "^(did:gatc:.+)$"
-      url: http://gataca-did-resolver-driver:8080/
+      url: ${uniresolver_web_driver_url_did_gatc:http://gataca-did-resolver-driver:8080/}
       testIdentifiers:
         - did:gatc:2xtSori9UQZdTqzxrkp7zqKM4Kj5B4C7
         - did:gatc:acYseLtTEVeqF8oBhJEejbCVHJ8auVupaRuo6gw4hmXjcc77uCKqyM3imEJH
         - did:gatc:MDU2OGVjYTViNGUzYmM2OGJiMGE1ZGM3
     - pattern: "^(did:icon:.+)$"
-      url: http://driver-did-icon:8080/
+      url: ${uniresolver_web_driver_url_did_icon:http://driver-did-icon:8080/}
       testIdentifiers:
         - did:icon:01:64aa0a2a479cb47afbf2d18d6f9f216bcdcbecdda27ccba3
     - pattern: "^(did:vaa:.+)$"
-      url: http://driver-did-vaa:8080/
+      url: ${uniresolver_web_driver_url_did_vaa:http://driver-did-vaa:8080/}
       testIdentifiers:
         - did:vaa:3wJVWDQWtDFx27FqvSqyo5xsTsxC
     - pattern: "^(did:unisot:.+)$"
-      url: http://unisot-did-driver:8080/
+      url: ${uniresolver_web_driver_url_did_unisot:http://unisot-did-driver:8080/}
       propertiesEndpoint: 'true'
       testIdentifiers:
         - did:unisot:test:n1aAmTXAg4o44Z9k8YCQncEY91r3TV7WU4
     - pattern: "^(did:sol:.+)$"
-      url: http://driver-did-sol:8080/
+      url: ${uniresolver_web_driver_url_did_sol:http://driver-did-sol:8080/}
       testIdentifiers:
         - did:sol:devnet:2eK2DKs6vdzTEoj842Gfcs6DdtffPpw1iF6JbzQL4TuK
     - pattern: "^(did:lit:(?:[1-9A-HJ-NP-Za-km-z]{21,22}))$"
-      url: http://driver-did-lit:8080/
+      url: ${uniresolver_web_driver_url_did_lit:http://driver-did-lit:8080/}
       testIdentifiers:
         - did:lit:AEZ87t1bi5bRxmVh3ksMUi
     - pattern: "^(did:ebsi:.+)$"
-      url: https://api-pilot.ebsi.eu/did-registry/v3/identifiers/$1
+      url: ${uniresolver_web_driver_url_did_ebsi:https://api-pilot.ebsi.eu/did-registry/v3/identifiers/$1}
       testIdentifiers:
         - did:ebsi:ziE2n8Ckhi6ut5Z8Cexrihd
     - pattern: "^(did:emtrust:.+)$"
-      url: http://driver-did-emtrust:8080/
+      url: ${uniresolver_web_driver_url_did_emtrust:http://driver-did-emtrust:8080/}
       testIdentifiers:
         - did:emtrust:0x242a5ac36676462bd58a
     - pattern: "^(did:meta:.+)$"
-      url: https://resolver.metadium.com/1.0/identifiers/$1
+      url: ${uniresolver_web_driver_url_did_meta:https://resolver.metadium.com/1.0/identifiers/$1}
       testIdentifiers:
         - did:meta:0000000000000000000000000000000000000000000000000000000000005e65
     - pattern: "^did:(?:tz:|pkh:|key:(?:z6Mk|z6LS|zQ3s|zDna|z82L|z2J9|z.{200,})).+$"
-      url: http://driver-didkit:3000/identifiers/$1
+      url: ${uniresolver_web_driver_url_did_kit:http://driver-didkit:3000/identifiers/$1}
       testIdentifiers:
         - did:tz:tz1YwA1FwpgLtc1G8DKbbZ6e6PTb1dQMRn5x
         - did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH
@@ -195,130 +195,130 @@ uniresolver:
         - did:key:z4MXj1wBzi9jUstyPMS4jQqB6KdJaiatPkAtVtGc6bQEQEEsKTic4G7Rou3iBf9vPmT5dbkm9qsZsuVNjq8HCuW1w24nhBFGkRE4cd2Uf2tfrB3N7h4mnyPp1BF3ZttHTYv3DLUPi1zMdkULiow3M1GfXkoC6DoxDUm1jmN6GBj22SjVsr6dxezRVQc7aj9TxE7JLbMH1wh5X3kA58H3DFW8rnYMakFGbca5CB2Jf6CnGQZmL7o5uJAdTwXfy2iiiyPxXEGerMhHwhjTA1mKYobyk2CpeEcmvynADfNZ5MBvcCS7m3XkFCMNUYBS9NQ3fze6vMSUPsNa6GVYmKx2x6JrdEjCk3qRMMmyjnjCMfR4pXbRMZa3i
         - did:pkh:tz:tz2BFTyPeYRzxd5aiBchbXN3WCZhx7BqbMBq
     - pattern: "^did:(?:key:(?:z5Tc|z3tE|zUC7)).+$"
-      url: http://driver-did-key:8080/1.0/identifiers/$1
+      url: ${uniresolver_web_driver_url_did_key:http://driver-did-key:8080/1.0/identifiers/$1}
       testIdentifiers:
         - did:key:z3tEFS9q2WkwvvVvr1BrYwNreqcudmcCQGGRSQ8r73recEqAUHGeLPWzwK6toBdKJgX3Fs
         - did:key:zUC7DWA2FazpvPXmiXeTWuLjdMGXXmmWXbwoKNo554L3E4PD5ZsoZPqzCvkFkkQGvWp6uLZ3PKQJMfXYzLGNoiMyqXYSQa19cvWTiH3QpzddfRVWW6FtFMWTcvUb7wg4o9khbDt
         - did:key:z5TcEoNqw2THWrFNZP62f2UmKMsuDnxmtYiNFHbVvqyPKUVyt7XfYmJ6HUsxmMYh2QWRctQ65HEw6BcPXxQevdAAWsd2aTNSjVUZ6VoyuPv8g8BySddJG9bDLGzey9EHSdYMcHYrYV8ycwKeNxcSrLqTCqxzDBHmyW6zEzDyYUoa8S8SAzAhVXF2uT19iyczDekWKZoPw
     - pattern: "^(did:orb:.+)$"
-      url: http://orb-did-driver:8121/1.0/identifiers/$1
+      url: ${uniresolver_web_driver_url_did_orb:http://orb-did-driver:8121/1.0/identifiers/$1}
       testIdentifiers:
         - did:orb:hl:uEiBuxTFn4L_Hn8KsOWo8e9kqWP38MThBaToB_5yV3c5QTg:uoQ-BeEJpcGZzOi8vYmFma3JlaWRveXV5d3B5Zjd5NnA0Zmxiem5pNmh4d2prbGQ2N3ltanlpZnV0dWFwN3RzazUzdHNxank:EiD_igS1OSEftg5BGfisJGOS1rgcx5AkQhX0h1B4dHTUYA
     - pattern: "^(did:oyd:.+)$"
-      url: https://oydid-resolver.data-container.net/1.0/identifiers/$1
+      url: ${uniresolver_web_driver_url_did_oyd:https://oydid-resolver.data-container.net/1.0/identifiers/$1}
       testIdentifiers:
         - did:oyd:zQmaBZTghndXTgxNwfbdpVLWdFf6faYE4oeuN2zzXdQt1kh
         - did:oyd:zQmNauTUUdkpi5TcrTZ2524SKM8dJAzuuw4xfW13iHrtY1W%40did2.data-container.net
     - pattern: "^(did:moncon:.+)$"
-      url: https://did.driver.moncon.co/1.0/identifiers/$1
+      url: ${uniresolver_web_driver_url_did_moncon:https://did.driver.moncon.co/1.0/identifiers/$1}
       testIdentifiers:
         - did:moncon:z6MkfrVYbLejh9Hv7Qmx4B2P681wBfPFkcHkbUCkgk1Q8LoA
     - pattern: "^(did:dock:.+)$"
-      url: http://dock-did-driver:8080/1.0/identifiers/$1
+      url: ${uniresolver_web_driver_url_did_dock:http://dock-did-driver:8080/1.0/identifiers/$1}
       testIdentifiers:
         - did:dock:5CxUdCGtopZEJhdv6kfLBZ22PMZX7UK8mdcHbTVw2nw6MVZH
         - did:dock:5CDsD8HZa6TeSfgmMcxAkbSXYWeob4jFQmtU6sxr4XWTZzUA
     - pattern: "^(did:mydata:.+)$"
-      url: http://mydata-did-driver:8080/1.0/identifiers/$1
+      url: ${uniresolver_web_driver_url_did_mydata:http://mydata-did-driver:8080/1.0/identifiers/$1}
       testIdentifiers:
         - did:mydata:z6MktaWPDXK7qwt9YgcGVuCFAXBvrEP3WPtxJQg37jnULXWL
         - did:mydata:z6MkjgVfx2YE7SUBZBej65E7UHSjAyMLukPvdPjPytpTy1ZM
     - pattern: "^(did:dns:.+)$"
-      url: http://driver-did-dns:8080/
+      url: ${uniresolver_web_driver_url_did_dns:http://driver-did-dns:8080/}
       propertiesEndpoint: 'true'
       testIdentifiers:
         - did:dns:danubetech.com
     - pattern: "^(did:everscale:.+)$"
-      url: http://everscale-did-driver:8080/
+      url: ${uniresolver_web_driver_url_did_everscale:http://everscale-did-driver:8080/}
       testIdentifiers:
         - did:everscale:47325e80e3cef5922d3a3583ae5c405ded7bda781cb069f2bc932a6c3d6ec62e
         - did:everscale:mainnet:47325e80e3cef5922d3a3583ae5c405ded7bda781cb069f2bc932a6c3d6ec62e
         - did:everscale:testnet:d760f69f830dfa0668f2e7923392217589ec8d62dcb90f2c06656665dba7fb4d
     - pattern: "^(did:ala:quor:redT:.+)$"
-      url: http://alastria-did-driver-mvp2:8080/1.0/identifiers/$1
+      url: ${uniresolver_web_driver_url_did_ala_quor_redt:http://alastria-did-driver-mvp2:8080/1.0/identifiers/$1}
       testIdentifiers:
         - did:ala:quor:redT:706b3e4611a855b8b1267c4e9f0c77124af003fe
         - did:ala:quor:redT:3729a1872356dd5c5ac377c85d539fe63cb561d8
         - did:ala:quor:redT:ec27f358fd0d11d8934ceb51305622ae79b6ad15
     - pattern: "^(did:cheqd:.+)$"
-      url: http://cheqd-did-driver:8080/1.0/identifiers/$1
+      url: ${uniresolver_web_driver_url_did_cheqd:http://cheqd-did-driver:8080/1.0/identifiers/$1}
       testIdentifiers:
         - did:cheqd:mainnet:Ps1ysXP2Ae6GBfxNhNQNKN
         - did:cheqd:testnet:55dbc8bf-fba3-4117-855c-1e0dc1d3bb47
     - pattern: "^(did:com:.+)$"
-      url: http://driver-did-com:8080/
+      url: ${uniresolver_web_driver_url_did_com:http://driver-did-com:8080/}
       testIdentifiers:
         - did:com:1l6zglh8pvcrjtahsvds2qmfpn0hv83vn8f9cf3
         - did:com:17rhmdzlv0zjuahw4mvpfhf3u5tuwyjhr4m06dr
     - pattern: "^(did:dyne:.+)$"
-      url: http://did-driver-dyne:8080/1.0/identifiers/$1
+      url: ${uniresolver_web_driver_url_did_dyne:http://did-driver-dyne:8080/1.0/identifiers/$1}
       testIdentifiers:
         - did:dyne:sandbox.test:JBdcDrTMkEuR8A2QnMQLRDXBL82AKxTpuHkxhmzgdkVH
         - did:dyne:demo_A:DBzNYB3ft2ncfeGaVV8aR5x95tU5hKUqGLYpDJifEVwu
         - did:dyne:demo:2r1FxbRA1EyfgeXh9TgEYT5RfkbMFUwLEmbYqeBajNbp
         - did:dyne:demo:FFqGYxShyDGAHd4QyLY1KFCSGBb1mBP9sZebEyBM7JPi
     - pattern: "^(did:jwk:.+)$"
-      url: http://did-jwk-driver:8080/1.0/identifiers/$1
+      url: ${uniresolver_web_driver_url_did_jwk:http://did-jwk-driver:8080/1.0/identifiers/$1}
       testIdentifiers:
         - did:jwk:eyJraWQiOiJ1cm46aWV0ZjpwYXJhbXM6b2F1dGg6andrLXRodW1icHJpbnQ6c2hhLTI1NjpGZk1iek9qTW1RNGVmVDZrdndUSUpqZWxUcWpsMHhqRUlXUTJxb2JzUk1NIiwia3R5IjoiT0tQIiwiY3J2IjoiRWQyNTUxOSIsImFsZyI6IkVkRFNBIiwieCI6IkFOUmpIX3p4Y0tCeHNqUlBVdHpSYnA3RlNWTEtKWFE5QVBYOU1QMWo3azQifQ
         - did:jwk:eyJraWQiOiJ1cm46aWV0ZjpwYXJhbXM6b2F1dGg6andrLXRodW1icHJpbnQ6c2hhLTI1Njpnc0w0VTRxX1J6VFhRckpwQUNnZGkwb1lCdUV1QjNZNWZFanhDd1NPUFlBIiwia3R5IjoiRUMiLCJjcnYiOiJQLTM4NCIsImFsZyI6IkVTMzg0IiwieCI6ImEtRWV5T2hlRUNWcDJqRkdVRTNqR0RCNlAzVV80S0lyZHRzTU9RQXFQN0NBMlVvV3NERG1nOWdJUVhiOEthd0ciLCJ5Ijoib3cxWDJ6VFVRaG12elY4NnpHdGhKc0xLeDE2MmhmSmxmN1p0OTFYUnZBTzRScE4zR2RGaVl3Tmc0NXJWUmlUcSJ9
     - pattern: "^(did:kscirc:.+)$"
-      url: http://did-kscirc-driver:8080/1.0/identifiers/$1
+      url: ${uniresolver_web_driver_url_did_kscirc:http://did-kscirc-driver:8080/1.0/identifiers/$1}
       testIdentifiers:
         - did:kscirc:k12NqvVM9BX6AaMjPK1hUTUkKBWPBAUXAszTxdx7jDZPv4iqCZ1D
         - did:kscirc:k17qQYbApdfTdxsrS77k3sbFmJCWfJf7QrvZSfMaAmq6MWpbeGs
     - pattern: "^(did:iscc:.+)$"
-      url: http://driver-did-iscc:8080/
+      url: ${uniresolver_web_driver_url_did_iscc:http://driver-did-iscc:8080/}
       testIdentifiers:
         - did:iscc:miagwptv4j2z57ci
     - pattern: "^(did:ev:.+)$"
-      url: http://driver-did-ev:8000/1.0/identifiers/$1
+      url: ${uniresolver_web_driver_url_did_ev:http://driver-did-ev:8000/1.0/identifiers/$1}
       testIdentifiers:
         - did:ev:bmM8apgHQD8cPbwNsMSJKqkYRCDYhkK55uxR9
         - did:ev:bmM8MpeJAGF2ky7YUnwgJGKxyHdCL6DGAUmEW
     - pattern: "^(did:iid:.+)$"
-      url: http://driver-did-iid:8080/1.0/identifiers/$1
+      url: ${uniresolver_web_driver_url_did_iid:http://driver-did-iid:8080/1.0/identifiers/$1}
       testIdentifiers:
         - did:iid:3QUs61mk7a9CdCpckriQbA5emw8pubj6RMtHXP6gD66YbcungS6w2sa
     - pattern: "^(did:evan:.+)$"
-      url: http://evan-did-driver:8080/
+      url: ${uniresolver_web_driver_url_did_evan:http://evan-did-driver:8080/}
       testIdentifiers:
         - did:evan:testcore:0x126E901F6F408f5E260d95c62E7c73D9B60fd734
     - pattern: "^(did:bid:.+)$"
-      url: http://driver-did-bid:8080/
+      url: ${uniresolver_web_driver_url_did_bid:http://driver-did-bid:8080/}
       testIdentifiers:
         - did:bid:ef214PmkhKndUcArDQPgD5J4fFVwqJFPt
     - pattern: "^(did:polygonid:.+)$"
-      url: http://driver-did-polygonid:8080/
+      url: ${uniresolver_web_driver_url_did_polygonid:http://driver-did-polygonid:8080/}
       propertiesEndpoint: 'true'
       testIdentifiers:
         - did:polygonid:polygon:mumbai:2qDj9EDytmvtQP1or3FxykXGEaqSA1ss479MYHDMJc
     - pattern: "^(did:pdc:.+)$"
-      url: http://driver-did-pdc:8080/
+      url: ${uniresolver_web_driver_url_did_pdc:http://driver-did-pdc:8080/}
       testIdentifiers:
         - did:pdc:8801:0xf47b66bc0d9b7c73f9ff27bf1f49a2b69dc167fc
     - pattern: "^(did:tys:(?:(?:\\w[-\\w]*(?::\\w[-\\w]*)*):)?(?:[1-9A-HJ-NP-Za-km-z]{21,29}))$"
-      url: http://driver-did-tys:8080/
+      url: ${uniresolver_web_driver_url_did_tys:http://driver-did-tys:8080/}
       testIdentifiers:
         - did:tys:4B4AbVzzcJSnCZsdX4VaKyQgHRnC
     - pattern: "^(did:plc:.+)$"
-      url: http://driver-did-plc:8000/
+      url: ${uniresolver_web_driver_url_did_plc:http://driver-did-plc:8000/}
       testIdentifiers:
         - did:plc:yk4dd2qkboz2yv6tpubpc6co
         - did:plc:44ybard66vv44zksje25o7dz
     - pattern: "^(did:evrc:.+)$"
-      url: http://driver-did-evrc:8080/
+      url: ${uniresolver_web_driver_url_did_evrc:http://driver-did-evrc:8080/}
       testIdentifiers:
         - did:evrc:issuer:ethereum:246d9b34-09e1-496e-ad5b-fb5ea889d96b
     - pattern: "^(did:keri:.+)$"
-      url: http://driver-did-keri:7678/
+      url: ${uniresolver_web_driver_url_did_kerri:http://driver-did-keri:7678/}
       testIdentifiers:
         - did:keri:EKYGGh-FtAphGmSZbsuBs_t4qpsjYJ2ZqvMKluq9OxmP
     - pattern: "^(did:webs:.+)$"
-      url: http://driver-did-webs:7677/
+      url: ${uniresolver_web_driver_url_did_webs:http://driver-did-webs:7677/}
       testIdentifiers:
         - did:webs:peacekeeper.github.io:did-webs-iiw37-tutorial:EKYGGh-FtAphGmSZbsuBs_t4qpsjYJ2ZqvMKluq9OxmP
     - pattern: "^(did:content:.+)$"
-      url: http://driver-did-content:8888/
+      url: ${uniresolver_web_driver_url_did_content:http://driver-did-content:8888/}
       testIdentifiers:
         - did:content:3SqTXtoMpiPeNo5vEP2p7yNGQUeCGjqW1wnctv8yaCWXojD29GYcUEo


### PR DESCRIPTION
**Issue Description :**

Currently the uni-resolver-web container application pulls the DID Driver locations and pattern matching expressions from the uni-resolver-web/src/main/resources/application.yml.  The driver URL fields are hardcoded strings in this file tailored to a docker-compose deployment/host naming, environment.   It would be preferable to inject the driver URLs into the deployment so that the uni-resolver-web image can be used in a wider range of underlying cloud deployment infrastructure. One example is AWS fargate where load balancers can use port addresses to direct traffic to different DID Driver containers.
Another example is where a developer may wish to switch between instances of the same DID Method driver for testing/comparison.

**Proposed Solution**

In this pull request there are two fairly simple file changes:
* In the docker-compose.yml an `environment` section has been created for the uni-resolver-web service.  A variable for each DID pattern in uni-resolver-web/src/main/resources/application.yml has been inserted using a consistent naming scheme based on the did method.  The purpose of this change is to allow .env variables to over-ride each did method driver `url` and pass these into the uni-resolver-web containers environment. 
* In the uni-resolver-web/src/main/resources/application.yml, each hardcoded `url` value has been replaced with a spring property placeholder (see [https://docs.spring.io/spring-boot/docs/current/reference/html/features.html#features.external-config.files.property-placeholders](https://docs.spring.io/spring-boot/docs/current/reference/html/features.html#features.external-config.files.property-placeholders) ) utilising the original hardcoded `url` as the `default`. This allows for the current behaviour to remain the default (i.e backwards compatible) but allow the flexibility of changing driver URLs at uni-resolver-web container runtime based on environment settings.