### PR TITLE
add livenessProbe for uni-resolver-web

### DIFF
--- a/ci/deploy-k8s-aws/app-specs/deployment-uni-resolver-web.yaml
+++ b/ci/deploy-k8s-aws/app-specs/deployment-uni-resolver-web.yaml
@@ -17,11 +17,18 @@ spec:
         app: uni-resolver-web
     spec:
       containers:
-      - name: uni-resolver-web
-        image: universalresolver/uni-resolver-web
-        imagePullPolicy: Always
-        ports:
-        - containerPort: 8080
+        - name: uni-resolver-web
+          image: universalresolver/uni-resolver-web
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: "/1.0/methods"
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
### Problem  Description
- uni-resolver-web seems to be failing from time to time (This is the reason the entire cluster becomes unresponsive), uni-resolver-web pod is healthy but unresponsive so Kubernetes is not restarting the pod.
### Solution
- By attaching a liveness probe this issue can be avoided by restarting when the pod is unresponsive.


##### With this PR I have made the changes for the liveness probe. 
