### PR TITLE
add cndid driver 

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ You should then be able to resolve identifiers locally using simple `curl` reque
 	curl -X GET 'http://localhost:8080/1.0/identifiers/did:iden3:polygon:amoy:xC8VZLUUfo5p9DWUawReh7QSstmYN6zR7qsQhQCsw?gist=f12d4f6fddeed78cb8b1faf1c6f4f171a590c1b05c484118a09847f5caa74d03'
 	curl -X GET 'http://localhost:8080/1.0/identifiers/did:iden3:polygon:amoy:xC8VZLUUfo5p9DWUawReh7QSstmYN6zR7qsQhQCsw?state=7a1a45d22b686cf1bd2f9fbecbed38b725a555e6d8ad68d3780feda9124b1a13'
 
+    curl -X GET http://localhost:8080/1.0/identifiers/did:cndid:sf24eYrmwXt6nx4fig3XJm7n9UP6PNRJ3
+
 You can also use an "Accept" header to request the DID document in a specific representation, e.g.:
 
 	curl -H "Accept: application/did+ld+json" https://dev.uniresolver.io/1.0/identifiers/did:sov:WRfXPg8dantKVubE3HX8pw
@@ -190,6 +192,8 @@ Are you developing a DID method and Universal Resolver driver? Click [Driver Dev
 
 | [did-zkjm](https://github.com/JupiterMetaZK/.github)                         	| 1.0.0            | 1.0.0                                             		     | [uni-resolver-driver-did-zkjm](https://hub.docker.com/r/saishibu38380/uni-resolver-driver-zkjm) 				  | ZKJM DID                                                                            |
 | [did-iden3](https://github.com/iden3/driver-did-iden3)              | 0.0.8          | [1.0.0](https://github.com/iden3/did-iden3/blob/main/did-iden3-method.md)                                         | [ghcr.io/iden3/driver-did-iden3:v0.0.8](https://github.com/iden3/driver-did-iden3/pkgs/container/driver-did-iden3)                                                                          | Iden3 DID    
+
+| [did-cndid](https://github.com/teleinfo-bif/uni-resolver-driver-did-cndid)                              | 1.0.0          | [1.0.0](https://github.com/teleinfo-bif/cndid/blob/main/doc/en/CNDID%20Protocol%20Specification.md)                | [teleinfo/driver-did-cndid](https://hub.docker.com/repository/docker/teleinfo/driver-did-cndid)                                                                | CN DID                                                                      |
 
 
 ## More Information

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,6 +76,7 @@ services:
       uniresolver_web_driver_url_did_content:
       uniresolver_web_driver_url_did_prism:
       uniresolver_web_driver_url_did_iden3:
+      uniresolver_web_driver_url_did_cndid:
 
   driver-did-btcr:
     image: universalresolver/driver-did-btcr:latest
@@ -392,3 +393,7 @@ services:
     image: saishibu38380/uni-resolver-driver-zkjm:v1.0.0
     ports:
       - "8081:8080"
+  driver-did-cndid:
+    image: teleinfo/driver-did-cndid:v1.0.0
+    ports:
+      - "8160:8080"

--- a/uni-resolver-web/src/main/resources/application.yml
+++ b/uni-resolver-web/src/main/resources/application.yml
@@ -368,3 +368,7 @@ uniresolver:
       supportsDereference: true
       testIdentifiers:
         - did:iden3:polygon:amoy:xC8VZLUUfo5p9DWUawReh7QSstmYN6zR7qsQhQCsw
+    - pattern: "^(did:cndid:.+)$"
+      url: ${uniresolver_web_driver_url_did_cndid:http://driver-did-cndid:8080/}
+      testIdentifiers:
+        - did:cndid:sf24eYrmwXt6nx4fig3XJm7n9UP6PNRJ3


### PR DESCRIPTION
Request to update the cndid did driver to the Universal Resolver.

The DID Method spec: https://github.com/teleinfo-bif/cndid/blob/main/doc/en/CNDID%20Protocol%20Specification.md

The DID Driver Implementation: https://github.com/teleinfo-bif/uni-resolver-driver-did-cndid

The DID Driver Image: https://hub.docker.com/repository/docker/teleinfo/driver-did-cndid
The PR to update the cndid DID method to the DID Method Registry has been submitted for merging:https://github.com/w3c/did-extensions/pull/629