### PR TITLE
Update docker-compose to use latest driver-did-webvh image tag

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -376,7 +376,7 @@ services:
     ports:
       - "8153:9090"
   driver-did-webvh:
-    image: ghcr.io/decentralized-identity/uni-resolver-driver-did-webvh:sha256-f1aff57f56ee4c0b5b5fbf754006a060c793714585f3e80fc44ab9ab6bc38dcc.sig
+    image: ghcr.io/decentralized-identity/uni-resolver-driver-did-webvh:main
     ports:
       - "8154:8080"
   driver-did-quarkid:


### PR DESCRIPTION
- Changed the image reference for the driver-did-webvh service in docker-compose.yml to use the 'main' tag instead of a specific SHA256 digest.