### PR TITLE
Update driver-did-webvh image and README test identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ You should then be able to resolve identifiers locally using simple `curl` reque
 	curl -X GET http://localhost:8080/1.0/identifiers/did:itn:PA7xLNkMAqzzrDp4UBnrZm
 	curl -X GET http://localhost:8080/1.0/identifiers/did:iota:0xf4d6f08f5a1b80dd578da7dc1b49c886d580acd4cf7d48119dfeb82b538ad88a
 	curl -X GET http://localhost:8080/1.0/identifiers/did:prism:c36cd59bbc62dee1925e1343a8fed051416e417116d6169d060746f1e6816cd4
- 	curl -X GET http://localhost:8080/1.0/identifiers/did:webvh:QmPEQVM1JPTyrvEgBcDXwjK4TeyLGSX1PxjgyeAisdWM1p:gist.githubusercontent.com:brianorwhatever:9c4633d18eb644f7a47f93a802691626:raw
+ 	curl -X GET http://localhost:8080/1.0/identifiers/did:webvh:QmVJ5nUYb9iugnUz4yDfbe8UFbhmnsvS2EAzSpSfPScRAn:opsecid.github.io
 	curl -X GET http://localhost:8080/1.0/identifiers/did:quarkid:EiBJ_1z9_OtvrfSgUNnBIs808vsRq7dQCKMP4LuSUosdXQ
 
 	curl -X GET http://localhost:8080/1.0/identifiers/did:zkjm:mainnet:d90e52b36a2e2306dc873ec0f7a94351

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -376,7 +376,7 @@ services:
     ports:
       - "8153:9090"
   driver-did-webvh:
-    image: ghcr.io/decentralized-identity/uni-resolver-driver-did-webvh:main
+    image: ghcr.io/decentralized-identity/uni-resolver-driver-did-webvh:v2.2.0-2715f15
     ports:
       - "8154:8080"
   driver-did-quarkid:

--- a/uni-resolver-web/src/main/resources/application.yml
+++ b/uni-resolver-web/src/main/resources/application.yml
@@ -354,6 +354,7 @@ uniresolver:
       url: ${uniresolver_web_driver_url_did_webvh:http://driver-did-webvh:8080/}
       testIdentifiers:
         - did:webvh:QmPEQVM1JPTyrvEgBcDXwjK4TeyLGSX1PxjgyeAisdWM1p:gist.githubusercontent.com:brianorwhatever:9c4633d18eb644f7a47f93a802691626:raw
+        - did:webvh:QmVJ5nUYb9iugnUz4yDfbe8UFbhmnsvS2EAzSpSfPScRAn:opsecid.github.io
     - pattern: "^(did:quarkid:.+)$"
       url: ${uniresolver_web_driver_url_did_quarkid:http://driver-did-quarkid:8080/}
       testIdentifiers:


### PR DESCRIPTION
- Updated the docker-compose.yml to use the new version v2.2.0-2715f15 for the driver-did-webvh image.
- Modified the README to update the test identifier for did:webvh to reflect the new format.

Closes https://github.com/decentralized-identity/didwebvh-ts/issues/60