### PR TITLE
fix: 0.2.7 fixes did:webs service verification bug

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -335,11 +335,11 @@ services:
     ports:
       - "8145:8080"
   driver-did-keri:
-    image: gleif/did-webs-resolver-service:0.2.6
+    image: gleif/did-webs-resolver-service:0.2.7
     ports:
       - "8146:7677"
   driver-did-webs:
-    image: gleif/did-webs-resolver-service:0.2.6
+    image: gleif/did-webs-resolver-service:0.2.7
     ports:
       - "8147:7677"
   driver-did-content:


### PR DESCRIPTION
Version 0.2.7 fixes the `service` DID doc verification bug and also fixes the HTTP 417 bug when resolving static DID assets by the resolver.