### PR TITLE
feat: update did:algo driver to 1.1.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -347,7 +347,7 @@ services:
     ports:
       - "8148:8888"
   driver-did-algo:
-    image: ghcr.io/algorandfoundation/did-algo:v1.0.0
+    image: ghcr.io/algorandfoundation/did-algo:v1.1.0
     ports:
       - "8149:9091"
   driver-did-itn:


### PR DESCRIPTION
The current driver uses a resolver that doesn't properly handle the `application/did-resolution` content type. This new image uses an updated resolver that handles all the expected content types, including `did-resolution`