### PR TITLE
hotfix: Use git to get version for Multi-Arch Docker Release

### DIFF
--- a/.github/workflows/docker-multi-arch.yml
+++ b/.github/workflows/docker-multi-arch.yml
@@ -95,6 +95,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
+          fetch-depth: 0
 
       - name: Import Secrets
         uses: hashicorp/vault-action@v3
@@ -117,10 +118,7 @@ jobs:
       - name: Get version
         if: inputs.IS_RELEASE
         id: get_version
-        uses: danubetech/github-action-read-version@main
-        with:
-          framework: ${{ inputs.GLOBAL_FRAMEWORK }}
-          version-core: ${{ inputs.RELEASE_TYPE }}
+        run: echo "version=$(git describe --abbrev=0)" >> $GITHUB_OUTPUT
 
       - name: Docker Metadata
         id: metadata
@@ -129,7 +127,7 @@ jobs:
           images: ${{ inputs.GLOBAL_REPO_NAME }}/${{ inputs.GLOBAL_IMAGE_NAME }}
           tags: |
             type=raw,value=${{ inputs.IMAGE_TAG }},enable=${{ inputs.IMAGE_TAG != '' }}
-            type=sha,prefix=${{ steps.get_version.outputs.releaseVersion }}-,enable=${{ inputs.IS_RELEASE }}
+            type=sha,prefix=${{ steps.get_version.outputs.version }}-,enable=${{ inputs.IS_RELEASE }}
 
       - name: Login to Docker Registry
         uses: docker/login-action@v3

--- a/.github/workflows/docker-multi-arch.yml
+++ b/.github/workflows/docker-multi-arch.yml
@@ -129,7 +129,7 @@ jobs:
           images: ${{ inputs.GLOBAL_REPO_NAME }}/${{ inputs.GLOBAL_IMAGE_NAME }}
           tags: |
             type=raw,value=${{ inputs.IMAGE_TAG }},enable=${{ inputs.IMAGE_TAG != '' }}
-            type=sha,prefix=${{ steps.get_version.outputs.version }},enable=${{ inputs.IS_RELEASE }}
+            type=sha,prefix=${{ steps.get_version.outputs.releaseVersion }}-,enable=${{ inputs.IS_RELEASE }}
 
       - name: Login to Docker Registry
         uses: docker/login-action@v3


### PR DESCRIPTION
Essentially a cherry-pick of https://github.com/decentralized-identity/universal-registrar/pull/99

---

* Add missing `-` to sha prefix tag
* Extract version from git
  * Based on https://github.com/danubetech/workflows/blob/5f5e6ea9e3021ecba83666018ff6420ee9a60e18/.github/workflows/maven-triggered-docker-release.yml#L35-L46