### PR TITLE
Add did:operon driver (proxy to Operon resolver)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -159,6 +159,11 @@ services:
     image: iotex/uni-resolver-driver-did-io:latest
     ports:
       - "8104:8080"
+
+  driver-did-operon:
+    image: ghcr.io/operonmaster/driver-did-operon:latest
+    ports:
+      - "8110:8080"
   bba-did-driver:
     container_name: bba-did-driver
     image: blobaa/bba-did-driver:0.2.2

--- a/docs/did/operon.md
+++ b/docs/did/operon.md
@@ -1,0 +1,8 @@
+# did:operon
+
+- **Specification**: https://operon.cloud/did-method/operon
+- **Resolver**: https://did.operon.cloud/1.0/identifiers/{did}
+- **Driver image**: ghcr.io/operonmaster/driver-did-operon:latest
+- **Test identifier**: `did:operon:root`
+
+This driver proxies Universal Resolver requests to the Operon DID resolver and returns DID Documents in `application/did+json` format.


### PR DESCRIPTION
Description template:

  - Register did:operon Universal Resolver driver
  - Driver image: ghcr.io/operonmaster/driver-did-operon:latest
  - Proxies to resolver: https://did.operon.cloud/1.0/identifiers/{did}
  - Spec: https://operon.cloud/did-method/operon
  - Test identifier: did:operon:root