### PR TITLE
Fix unknown network 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -424,8 +424,6 @@ services:
     image: davidgbvargroup/uni-resolver-driver-did-andorra:1.0.1
     ports:
       - "8164:8080"
-    networks:
-      - universal-resolver
 
   driver-did-hedera:
     image: ghcr.io/hiero-ledger/uni-resolver-driver-did-hedera:v0.1.7-8ae3a53


### PR DESCRIPTION
Docker Compose version v2.40.3

Use default network in driver-did-andorra
Removed the 'networks' section for the 'driver-did-andorra' service.

Fixes 
```
service "driver-did-andorra" refers to undefined network universal-resolver: invalid compose project
```