### PR TITLE
feat: add did:moltrust Universal Resolver driver

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -450,3 +450,8 @@ services:
     environment:
       ALGOD_URL: ${uniresolver_driver_did_nfd_algod_url}
       ALGOD_TOKEN: ${uniresolver_driver_did_nfd_algod_token}
+
+  driver-did-moltrust:
+    image: moltrust/driver-did-moltrust:1.0.0
+    ports:
+      - "8168:8080"

--- a/uni-resolver-web/src/main/resources/application.yml
+++ b/uni-resolver-web/src/main/resources/application.yml
@@ -438,3 +438,8 @@ uniresolver:
       testIdentifiers:
         - did:nfd:nfdomains.algo
         - did:nfd:algorand.algo
+
+    - pattern: "^(did:moltrust:.+)$"
+      url: ${uniresolver_web_driver_url_did_moltrust:http://driver-did-moltrust:8080/1.0/identifiers/$1}
+      testIdentifiers:
+        - did:moltrust:d34ed796a4dc4698


### PR DESCRIPTION
## Summary

Adds a Universal Resolver driver for the `did:moltrust` DID method.

**MolTrust** is W3C DID/VC trust infrastructure for autonomous AI agents — cryptographic identity, behavioral trust scoring, and on-chain provenance anchoring on Base L2.

## Driver Details

| Field | Value |
|-------|-------|
| DID Method | `did:moltrust` |
| Image | `moltrust/driver-did-moltrust:1.0.0` |
| Port | 8168:8080 |
| Source | [MoltyCel/driver-did-moltrust](https://github.com/MoltyCel/driver-did-moltrust) |
| Registry API | `https://api.moltrust.ch/identity/resolve/{did}` |
| Test DID | `did:moltrust:d34ed796a4dc4698` |

## Test

```bash
curl https://api.moltrust.ch/identity/resolve/did:moltrust:d34ed796a4dc4698
```

## Specification

- [MolTrust Protocol TechSpec v0.8.1](https://moltrust.ch)
- [A2A v0.3 Agent Card](https://api.moltrust.ch/.well-known/agent-card.json)
- 38 registered agents, 35,897 interaction proof records anchored on Base L2

## Operator

CryptoKRI GmbH, Zurich, Switzerland
https://moltrust.ch

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)