### PR TITLE
Add did:cuil driver — Argentine CUIL decentralized identifier

### DIFF
--- a/.env
+++ b/.env
@@ -76,3 +76,4 @@ uniresolver_driver_did_art_RESOLVER_API_URL=https://did-art.articulator.ai
 uniresolver_driver_did_nfd_algod_url=https://mainnet-api.4160.nodely.dev
 uniresolver_driver_did_nfd_algod_token=
 
+uniresolver_web_driver_url_did_cuil=http://driver-did-cuil:8080/1.0/identifiers/

--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ Are you developing a DID method and Universal Resolver driver? Click [Driver Dev
 | [did-nfd](https://github.com/TxnLab/nfd-did)                                          | 0.1.0          | [1.0](https://github.com/TxnLab/nfd-did/blob/main/docs/DID_NFD_METHOD_SPEC.md)                                | [txnlab/did-nfd-resolver](https://hub.docker.com/repository/docker/txnlab/did-nfd-resolver)                                                                                  | NFDomains DID Method                                                                |
 
 | [did-art](https://github.com/ArtracID/ArtracID-DID-ART-Method) | 1.0.0 | [spec](https://github.com/ArtracID/ArtracID-DID-ART-Method) | [worthyopponent30/did-art-resolver](https://hub.docker.com/r/worthyopponent30/did-art-resolver) | DID:ART for digital artwork |
+| [did-cuil](https://github.com/firmared/uni-resolver-driver-did-cuil) | 1.0.0 | [1.0](https://firmared.com/did-spec/cuil/v1) | [firmared/uni-resolver-driver-did-cuil](https://hub.docker.com/r/firmared/uni-resolver-driver-did-cuil) | protocolo@firmared.com |
 
 
 ## More Information

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -450,3 +450,8 @@ services:
     environment:
       ALGOD_URL: ${uniresolver_driver_did_nfd_algod_url}
       ALGOD_TOKEN: ${uniresolver_driver_did_nfd_algod_token}
+
+  driver-did-cuil:
+    image: firmared/uni-resolver-driver-did-cuil:1.0.0
+    ports:
+      - "8181:8080"

--- a/uni-resolver-web/src/main/resources/application.yml
+++ b/uni-resolver-web/src/main/resources/application.yml
@@ -438,3 +438,8 @@ uniresolver:
       testIdentifiers:
         - did:nfd:nfdomains.algo
         - did:nfd:algorand.algo
+    - pattern: "^(did:cuil:.+)$"
+      url: ${uniresolver_web_driver_url_did_cuil:http://driver-did-cuil:8080/1.0/identifiers/$1}
+      testIdentifiers:
+        - did:cuil:20378029067
+        - did:cuil:27371284609


### PR DESCRIPTION
## Add driver for did:cuil DID method

### Summary
This PR adds a Universal Resolver driver for the `did:cuil` DID method, which enables decentralized identifiers for natural persons identified by the Argentine **CUIL** (Código Único de Identificación Laboral — Argentine fiscal identifier).

### DID Method
- **Specification:** https://firmared.com/did-spec/cuil/v1
- **W3C DID Extensions PR:** https://github.com/w3c/did-extensions/pull/698
- **Method:** `did:cuil`

### Driver
- **Docker image:** `firmared/uni-resolver-driver-did-cuil:1.0.0`
- **Docker Hub:** https://hub.docker.com/r/firmared/uni-resolver-driver-did-cuil
- **Port:** 8181
- **Source:** https://github.com/firmared/uni-resolver-driver-did-cuil

### Test identifiers
- `did:cuil:20378029067`
- `did:cuil:27371284609`

### Files changed
- `docker-compose.yml` — added driver-did-cuil service on port 8181
- `uni-resolver-web/src/main/resources/application.yml` — added pattern and test identifiers
- `.env` — added driver URL variable
- `README.md` — added row to driver table

### Contact
protocolo@firmared.com