### PR TITLE
Add did:battua driver (quantum-safe DID method)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,6 +80,7 @@ services:
       uniresolver_web_driver_url_did_empe:
       uniresolver_web_driver_url_did_hedera:
       uniresolver_web_driver_url_did_nfd:
+      uniresolver_web_driver_url_did_battua:
 
   driver-did-btcr:
     image: universalresolver/driver-did-btcr:latest
@@ -450,3 +451,10 @@ services:
     environment:
       ALGOD_URL: ${uniresolver_driver_did_nfd_algod_url}
       ALGOD_TOKEN: ${uniresolver_driver_did_nfd_algod_token}
+
+  driver-did-battua:
+    image: aurigraph/did-battua-driver:0.1.0
+    ports:
+      - "8168:8080"
+    environment:
+      BATTUA_API_URL: ${uniresolver_driver_did_battua_api_url:-https://battua.io}

--- a/uni-resolver-web/src/main/resources/application.yml
+++ b/uni-resolver-web/src/main/resources/application.yml
@@ -438,3 +438,13 @@ uniresolver:
       testIdentifiers:
         - did:nfd:nfdomains.algo
         - did:nfd:algorand.algo
+
+    - pattern: "^(did:battua:.+)$"
+      url: ${uniresolver_web_driver_url_did_battua:http://driver-did-battua:8080/1.0/identifiers/$1}
+      testIdentifiers:
+        - did:battua:1:0x74b466c1dedba290b7e17db99fcaf824a1c10a75
+      traits:
+        deactivatable: false
+        enumerable: false
+        historyAvailable: true
+        humanReadable: false


### PR DESCRIPTION
## Summary

Adds the `did:battua` DID method driver to the Universal Resolver.

- **DID method**: `did:battua` — quantum-safe digital identity on the Aurigraph DLT network
- **Cryptography**: ML-DSA-87 (Dilithium5) post-quantum signatures (NIST FIPS 204)
- **Driver image**: `aurigraph/did-battua-driver:0.1.0` (Node.js 20, Alpine-based, ~45MB)
- **Resolution endpoint**: `http://driver-did-battua:8080/1.0/identifiers/{did}`
- **Port**: 8168

## Changes

- `application.yml`: Added driver entry with pattern `^(did:battua:.+)$`, test identifier, and traits
- `docker-compose.yml`: Added `driver-did-battua` service + env var reference

## Driver details

| Property | Value |
|----------|-------|
| DID method spec | https://battua.io/did-method-spec |
| Source code | https://github.com/Aurigraph-DLT-Corp/Battua/tree/main/did-battua-driver |
| Docker image | `aurigraph/did-battua-driver:0.1.0` |
| W3C compliant | Yes (DID Resolution v1.0) |
| Test identifier | `did:battua:1:0x74b466c1dedba290b7e17db99fcaf824a1c10a75` |

## Test plan

- [ ] `docker compose up driver-did-battua` starts and passes healthcheck
- [ ] `curl http://localhost:8168/1.0/identifiers/did:battua:1:0x74b466c1dedba290b7e17db99fcaf824a1c10a75` returns valid DID document

---

Submitted by Aurigraph DLT Corp (https://aurigraph.io)