### PR TITLE
feat: add driver for did:trail

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,6 +81,11 @@ services:
       uniresolver_web_driver_url_did_hedera:
       uniresolver_web_driver_url_did_nfd:
 
+  driver-did-trail:
+    image: ghcr.io/trailprotocol/did-trail-universal-resolver-driver:latest
+    ports:
+      - "8086:8080"
+
   driver-did-btcr:
     image: universalresolver/driver-did-btcr:latest
     environment:

--- a/uni-resolver-web/src/main/resources/application.yml
+++ b/uni-resolver-web/src/main/resources/application.yml
@@ -15,6 +15,14 @@ spring:
 
 uniresolver:
   drivers:
+    - pattern: "^(did:trail:.+)$"
+      url: ${uniresolver_web_driver_url_did_trail:http://driver-did-trail:8080/}
+      testIdentifiers:
+        - did:trail:self:zEFoeeXsQtCAK9itr35Hf8W2HF5tAPTrKUKK1nC3RnUx4
+      traits:
+        deactivatable: false
+        enumerable: false
+        historyAvailable: false
     - pattern: "^(did:btcr:.+)$"
       url: ${uniresolver_web_driver_url_did_btcr:http://driver-did-btcr:8080/}
       propertiesEndpoint: "true"


### PR DESCRIPTION
This PR adds a driver for the **did:trail** DID method.

did:trail is a W3C DID method for AI agent identity, built on DID Core v1.1 with DataIntegrityProof / eddsa-jcs-2023. Three trust tiers: self-signed (Tier 0), org (Tier 1), agent (Tier 2).

- Method spec: https://trailprotocol.org
- W3C DID Extensions registry PR: w3c/did-extensions#669
- Driver repo: https://github.com/trailprotocol/did-trail-universal-resolver-driver
- Image: `ghcr.io/trailprotocol/did-trail-universal-resolver-driver:latest`

**Tier 0 (self-signed)** is implemented and resolves without a registry — the public key is encoded in the DID itself. Tier 1 and Tier 2 require the TRAIL Registry (in development); the driver returns `notFound` for those until the registry is live.

**Test identifier**

```
did:trail:self:zEFoeeXsQtCAK9itr35Hf8W2HF5tAPTrKUKK1nC3RnUx4
```

**Changes**

- `uni-resolver-web/src/main/resources/application.yml` — driver pattern + test identifier
- `docker-compose.yml` — `driver-did-trail` service on port 8086