### PR TITLE
feat: Add local driver class instantiation support for did:proof

### DIFF
--- a/uni-resolver-local/example-config.json
+++ b/uni-resolver-local/example-config.json
@@ -1,0 +1,23 @@
+{
+  "drivers": [
+    {
+      "pattern": "^(did:proof:z[A-Za-z0-9]{20,})$",
+      "driverClass": "uniresolver.driver.did.proof.DidProofDriver",
+      "testIdentifiers": [
+        "did:proof:z6MkfrQC9BjKJzKVh6eNkJQZmUZ6a4Qz8EJGwE7VzKdKjNQ"
+      ],
+      "traits": {
+        "deactivatable": false,
+        "enumerable": false
+      }
+    },
+    {
+      "pattern": "^(did:example:.+)$",
+      "url": "http://example-driver:8080/",
+      "propertiesEndpoint": "true",
+      "testIdentifiers": [
+        "did:example:123456789"
+      ]
+    }
+  ]
+}

--- a/uni-resolver-local/src/main/java/uniresolver/local/configuration/LocalUniResolverConfigurator.java
+++ b/uni-resolver-local/src/main/java/uniresolver/local/configuration/LocalUniResolverConfigurator.java
@@ -33,6 +33,7 @@ public class LocalUniResolverConfigurator {
             for (Map<String, Object> jsonDriver : jsonDrivers) {
 
                 String pattern = jsonDriver.containsKey("pattern") ? (String) jsonDriver.get("pattern") : null;
+                String driverClass = jsonDriver.containsKey("driverClass") ? (String) jsonDriver.get("driverClass") : null;
                 String url = jsonDriver.containsKey("url") ? (String) jsonDriver.get("url") : null;
                 String propertiesEndpoint = jsonDriver.containsKey("propertiesEndpoint") ? (String) jsonDriver.get("propertiesEndpoint") : null;
                 String supportsOptions = jsonDriver.containsKey("supportsOptions") ? (String) jsonDriver.get("supportsOptions") : null;
@@ -42,8 +43,15 @@ public class LocalUniResolverConfigurator {
                 List<String> testIdentifiers = jsonDriver.containsKey("testIdentifiers") ? (List<String>) jsonDriver.get("testIdentifiers") : null;
                 Map<String, Object> traits = jsonDriver.containsKey("traits") ? (Map<String, Object>) jsonDriver.get("traits") : null;
 
-                if (pattern == null) throw new IllegalArgumentException("Missing 'pattern' entry in driver configuration.");
-                if (url == null) throw new IllegalArgumentException("Missing 'url' entry in driver configuration.");
+                if (pattern == null && driverClass == null) throw new IllegalArgumentException("Missing 'pattern' entry in driver configuration.");
+                if (driverClass == null && url == null) throw new IllegalArgumentException("Missing 'url' entry in driver configuration.");
+
+                if (driverClass != null) {
+                    Driver driver = instantiateDriverClass(driverClass);
+                    drivers.add(driver);
+                    if (log.isInfoEnabled()) log.info("Added local driver class '" + driverClass + "'");
+                    continue;
+                }
 
                 // construct HTTP driver
 
@@ -76,5 +84,14 @@ public class LocalUniResolverConfigurator {
         // done
 
         localUniResolver.setDrivers(drivers);
+    }
+
+    private static Driver instantiateDriverClass(String driverClass) {
+        try {
+            Class<? extends Driver> clazz = Class.forName(driverClass).asSubclass(Driver.class);
+            return clazz.getDeclaredConstructor().newInstance();
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Unable to instantiate driver class '" + driverClass + "'", e);
+        }
     }
 }

--- a/uni-resolver-web/src/main/java/uniresolver/web/config/DriverConfigs.java
+++ b/uni-resolver-web/src/main/java/uniresolver/web/config/DriverConfigs.java
@@ -23,6 +23,7 @@ public class DriverConfigs {
 	public static class DriverConfig {
 
 		private String pattern;
+		private String driverClass;
 		private String url;
 		private String propertiesEndpoint;
 		private String supportsOptions;
@@ -38,6 +39,14 @@ public class DriverConfigs {
 
 		public void setPattern(String value) {
 			this.pattern = value;
+		}
+
+		public String getDriverClass() {
+			return driverClass;
+		}
+
+		public void setDriverClass(String driverClass) {
+			this.driverClass = driverClass;
 		}
 
 		public String getUrl() {
@@ -108,6 +117,7 @@ public class DriverConfigs {
 		public String toString() {
 			return "DriverConfig{" +
 					"pattern='" + pattern + '\'' +
+					", driverClass='" + driverClass + '\'' +
 					", url='" + url + '\'' +
 					", propertiesEndpoint='" + propertiesEndpoint + '\'' +
 					", supportsOptions='" + supportsOptions + '\'' +

--- a/uni-resolver-web/src/main/java/uniresolver/web/config/WebAppConfig.java
+++ b/uni-resolver-web/src/main/java/uniresolver/web/config/WebAppConfig.java
@@ -105,6 +105,7 @@ public class WebAppConfig {
 		for (DriverConfigs.DriverConfig driverConfig : driverConfigs.getDrivers()) {
 
 			String pattern = driverConfig.getPattern();
+			String driverClass = driverConfig.getDriverClass();
 			String url = driverConfig.getUrl();
 			String propertiesEndpoint = driverConfig.getPropertiesEndpoint();
 			String supportsOptions = driverConfig.getSupportsOptions();
@@ -114,7 +115,16 @@ public class WebAppConfig {
 			List<String> testIdentifiers = driverConfig.getTestIdentifiers();
 			Map<String, Object> traits = driverConfig.getTraits();
 
-			if (pattern == null) throw new IllegalArgumentException("Missing 'pattern' entry in driver configuration.");
+			if (pattern == null && driverClass == null) throw new IllegalArgumentException("Missing 'pattern' entry in driver configuration.");
+
+			// Handle local driver class instantiation
+			if (driverClass != null) {
+				Driver driver = this.instantiateDriverClass(driverClass);
+				drivers.add(driver);
+				if (log.isInfoEnabled()) log.info("Added local driver class '" + driverClass + "'");
+				continue;
+			}
+
 			if (url == null) throw new IllegalArgumentException("Missing 'url' entry in driver configuration.");
 
 			// construct HTTP driver
@@ -145,6 +155,19 @@ public class WebAppConfig {
 		}
 
 		uniResolver.setDrivers(drivers);
+	}
+
+	private Driver instantiateDriverClass(String driverClass) {
+		try {
+			Class<?> clazz = Class.forName(driverClass);
+			Object instance = clazz.getDeclaredConstructor().newInstance();
+			if (!(instance instanceof Driver)) {
+				throw new IllegalArgumentException("Driver class '" + driverClass + "' does not implement the Driver interface");
+			}
+			return (Driver) instance;
+		} catch (Exception e) {
+			throw new IllegalArgumentException("Unable to instantiate driver class '" + driverClass + "'", e);
+		}
 	}
 
 	@PostConstruct

--- a/uni-resolver-web/src/main/resources/application.yml
+++ b/uni-resolver-web/src/main/resources/application.yml
@@ -451,3 +451,10 @@ uniresolver:
       testIdentifiers:
         - did:webplus:ledgerdomain.github.io:did-webplus-spec:uFiANVlMledNFUBJNiZPuvfgzxvJlGGDBIpDFpM4DXW6Bow
         - did:webplus:ledgerdomain.github.io:did-webplus-spec:uFiDBw4xANa8sR_Fd8-pv-X9A5XIJNS3tC_bRNB3HUYiKug
+    - pattern: "^(did:proof:z[A-Za-z0-9]{20,})$"
+      driverClass: uniresolver.driver.did.proof.DidProofDriver
+      testIdentifiers:
+        - did:proof:z6MkfrQC9BjKJzKVh6eNkJQZmUZ6a4Qz8EJGwE7VzKdKjNQ
+      traits:
+        deactivatable: false
+        enumerable: false


### PR DESCRIPTION
This PR adds support for the **did:proof** method to the Universal Resolver by introducing a new local driver. The did:proof method is designed as part of the PaperProof ecosystem and resolves DIDs by retrieving DID Documents with embedded proof metadata.

**Driver Details:**

- **DID Method:** did:proof
- **Driver Repository:** [PaperProofLabs/uni-resolver-driver-did-proof](https://github.com/PaperProofLabs/uni-resolver-driver-did-proof)
- **Specification Repository:** [PaperProofLabs/proof](https://github.com/PaperProofLabs/proof)

**Key Features:**

- **Local Driver Class Instantiation:** This PR introduces support for registering drivers via local Java class instantiation (not just HTTP endpoints), enabling more efficient driver loading.
- **DID Pattern Validation:** The driver validates did:proof identifiers using the pattern `^(did:proof:z[A-Za-z0-9]{20,})$`
- **Query Parameter Parsing:** Supports optional query parameters for customizing resolution behavior
- **Full Driver Interface Implementation:** Implements all required Driver interface methods including `resolve()`, `dereference()`, `properties()`, `testIdentifiers()`, and `traits()`

**Resolution Flow:**

1. The Universal Resolver routes did:proof identifiers to this driver
2. The driver validates the DID format and extracts the method-specific ID
3. The driver constructs a DID Document with proof-related metadata
4. The DID Document is returned in compliance with DID Core resolution format

**Framework Changes:**

- Extended `LocalUniResolverConfigurator` to support `driverClass` field for local instantiation
- Updated Spring Boot configuration in `WebAppConfig` to handle local drivers
- Added `driverClass` property binding in `DriverConfigs`
- Maintained backward compatibility with existing HTTP-based drivers