### PR TITLE
Add did:cosmos AtomRegistry driver

### DIFF
--- a/driver/driver-did-cosmos-atomregistry.json
+++ b/driver/driver-did-cosmos-atomregistry.json
@@ -1,0 +1,14 @@
+{
+  "name": "did-cosmos-atomregistry",
+  "pattern": "^(did:cosmos:(1:)?cosmoshub:atomregistry:.+)$",
+  "url": "did.atomregistry.com/1.0/identifiers/",
+  "testIdentifiers": [
+    "did:cosmos:1:cosmoshub:atomregistry:alice.atom",
+    "did:cosmos:cosmoshub:atomregistry:alice.atom"
+  ],
+  "properties": {
+    "chainId": "cosmoshub-4",
+    "chainspace": "cosmoshub",
+    "namespace": "atomregistry"
+  }
+}


### PR DESCRIPTION
Adds a Universal Resolver driver for AtomRegistry domains on Cosmos Hub.

Method: did

Pattern: did:cosmos:(1:)?cosmoshub:atomregistry:

Driver URL: did.atomregistry.com

Chain: cosmoshub-4 (Cosmos Hub mainnet)

Driver resolves AtomRegistry domains to W3C DID documents using on-chain data from CosmWasm contracts.

Test:

curl 'did.atomregistry.com/1.0/identifiers/did%3Acosmos%3A1%3Acosmoshub%3Aatomregistry%3Acosmos.atom'
7:43 AM