### PR TITLE
feat: wire did:oan into universal resolver configuration

### DIFF
--- a/uni-resolver-local/example-config.json
+++ b/uni-resolver-local/example-config.json
@@ -1,0 +1,25 @@
+{
+  "drivers": [
+    {
+      "pattern": "^(did:oan:[A-Za-z0-9]{4}:[1-9A-HJ-NP-Za-km-z]{32})$",
+      "driverClass": "uniresolver.driver.did.oan.DidOanDriver",
+      "testIdentifiers": [
+        "did:oan:AGFI:7YpQm9Kx2VnRb6Ts3WfHa4Cd5Ej8LgNz"
+      ],
+      "traits": {
+        "deactivatable": true,
+        "enumerable": false,
+        "historyAvailable": false,
+        "humanReadable": false
+      }
+    },
+    {
+      "pattern": "^(did:example:.+)$",
+      "url": "http://example-driver:8080/",
+      "propertiesEndpoint": "true",
+      "testIdentifiers": [
+        "did:example:123456789"
+      ]
+    }
+  ]
+}

--- a/uni-resolver-local/src/main/java/uniresolver/local/configuration/LocalUniResolverConfigurator.java
+++ b/uni-resolver-local/src/main/java/uniresolver/local/configuration/LocalUniResolverConfigurator.java
@@ -33,6 +33,7 @@ public class LocalUniResolverConfigurator {
             for (Map<String, Object> jsonDriver : jsonDrivers) {
 
                 String pattern = jsonDriver.containsKey("pattern") ? (String) jsonDriver.get("pattern") : null;
+                String driverClass = jsonDriver.containsKey("driverClass") ? (String) jsonDriver.get("driverClass") : null;
                 String url = jsonDriver.containsKey("url") ? (String) jsonDriver.get("url") : null;
                 String propertiesEndpoint = jsonDriver.containsKey("propertiesEndpoint") ? (String) jsonDriver.get("propertiesEndpoint") : null;
                 String supportsOptions = jsonDriver.containsKey("supportsOptions") ? (String) jsonDriver.get("supportsOptions") : null;
@@ -42,8 +43,15 @@ public class LocalUniResolverConfigurator {
                 List<String> testIdentifiers = jsonDriver.containsKey("testIdentifiers") ? (List<String>) jsonDriver.get("testIdentifiers") : null;
                 Map<String, Object> traits = jsonDriver.containsKey("traits") ? (Map<String, Object>) jsonDriver.get("traits") : null;
 
-                if (pattern == null) throw new IllegalArgumentException("Missing 'pattern' entry in driver configuration.");
-                if (url == null) throw new IllegalArgumentException("Missing 'url' entry in driver configuration.");
+                if (pattern == null && driverClass == null) throw new IllegalArgumentException("Missing 'pattern' entry in driver configuration.");
+                if (driverClass == null && url == null) throw new IllegalArgumentException("Missing 'url' entry in driver configuration.");
+
+                if (driverClass != null) {
+                    Driver driver = instantiateDriverClass(driverClass);
+                    drivers.add(driver);
+                    if (log.isInfoEnabled()) log.info("Added local driver class '" + driverClass + "'");
+                    continue;
+                }
 
                 // construct HTTP driver
 
@@ -76,5 +84,14 @@ public class LocalUniResolverConfigurator {
         // done
 
         localUniResolver.setDrivers(drivers);
+    }
+
+    private static Driver instantiateDriverClass(String driverClass) {
+        try {
+            Class<? extends Driver> clazz = Class.forName(driverClass).asSubclass(Driver.class);
+            return clazz.getDeclaredConstructor().newInstance();
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Unable to instantiate driver class '" + driverClass + "'", e);
+        }
     }
 }

--- a/uni-resolver-web/src/main/java/uniresolver/web/config/DriverConfigs.java
+++ b/uni-resolver-web/src/main/java/uniresolver/web/config/DriverConfigs.java
@@ -23,6 +23,7 @@ public class DriverConfigs {
 	public static class DriverConfig {
 
 		private String pattern;
+		private String driverClass;
 		private String url;
 		private String propertiesEndpoint;
 		private String supportsOptions;
@@ -42,6 +43,14 @@ public class DriverConfigs {
 
 		public String getUrl() {
 			return url;
+		}
+
+		public String getDriverClass() {
+			return driverClass;
+		}
+
+		public void setDriverClass(String driverClass) {
+			this.driverClass = driverClass;
 		}
 
 		public void setUrl(String value) {
@@ -108,6 +117,7 @@ public class DriverConfigs {
 		public String toString() {
 			return "DriverConfig{" +
 					"pattern='" + pattern + '\'' +
+					", driverClass='" + driverClass + '\'' +
 					", url='" + url + '\'' +
 					", propertiesEndpoint='" + propertiesEndpoint + '\'' +
 					", supportsOptions='" + supportsOptions + '\'' +

--- a/uni-resolver-web/src/main/java/uniresolver/web/config/WebAppConfig.java
+++ b/uni-resolver-web/src/main/java/uniresolver/web/config/WebAppConfig.java
@@ -105,6 +105,7 @@ public class WebAppConfig {
 		for (DriverConfigs.DriverConfig driverConfig : driverConfigs.getDrivers()) {
 
 			String pattern = driverConfig.getPattern();
+			String driverClass = driverConfig.getDriverClass();
 			String url = driverConfig.getUrl();
 			String propertiesEndpoint = driverConfig.getPropertiesEndpoint();
 			String supportsOptions = driverConfig.getSupportsOptions();
@@ -114,7 +115,15 @@ public class WebAppConfig {
 			List<String> testIdentifiers = driverConfig.getTestIdentifiers();
 			Map<String, Object> traits = driverConfig.getTraits();
 
-			if (pattern == null) throw new IllegalArgumentException("Missing 'pattern' entry in driver configuration.");
+			if (pattern == null && driverClass == null) throw new IllegalArgumentException("Missing 'pattern' entry in driver configuration.");
+
+			if (driverClass != null) {
+				Driver driver = this.instantiateDriverClass(driverClass);
+				drivers.add(driver);
+				if (log.isInfoEnabled()) log.info("Added local driver class '" + driverClass + "'");
+				continue;
+			}
+
 			if (url == null) throw new IllegalArgumentException("Missing 'url' entry in driver configuration.");
 
 			// construct HTTP driver
@@ -145,6 +154,19 @@ public class WebAppConfig {
 		}
 
 		uniResolver.setDrivers(drivers);
+	}
+
+	private Driver instantiateDriverClass(String driverClass) {
+		try {
+			Class<?> clazz = Class.forName(driverClass);
+			Object instance = clazz.getDeclaredConstructor().newInstance();
+			if (!(instance instanceof Driver)) {
+				throw new IllegalArgumentException("Driver class '" + driverClass + "' does not implement the Driver interface");
+			}
+			return (Driver) instance;
+		} catch (Exception e) {
+			throw new IllegalArgumentException("Unable to instantiate driver class '" + driverClass + "'", e);
+		}
 	}
 
 	@PostConstruct

--- a/uni-resolver-web/src/main/resources/application.yml
+++ b/uni-resolver-web/src/main/resources/application.yml
@@ -451,3 +451,12 @@ uniresolver:
       testIdentifiers:
         - did:webplus:ledgerdomain.github.io:did-webplus-spec:uFiANVlMledNFUBJNiZPuvfgzxvJlGGDBIpDFpM4DXW6Bow
         - did:webplus:ledgerdomain.github.io:did-webplus-spec:uFiDBw4xANa8sR_Fd8-pv-X9A5XIJNS3tC_bRNB3HUYiKug
+    - pattern: "^(did:oan:[A-Za-z0-9]{4}:[1-9A-HJ-NP-Za-km-z]{32})$"
+      driverClass: uniresolver.driver.did.oan.DidOanDriver
+      testIdentifiers:
+        - did:oan:AGFI:7YpQm9Kx2VnRb6Ts3WfHa4Cd5Ej8LgNz
+      traits:
+        deactivatable: true
+        enumerable: false
+        historyAvailable: false
+        humanReadable: false


### PR DESCRIPTION
Add local driverClass support and did:oan configuration entries so the universal resolver fork can host a native did:oan driver.

Changes include:

- support driverClass-based instantiation in local and web configurators

- extend driver configuration objects to carry driverClass

- add did:oan entries to application.yml and local example config

- keep the universal resolver wiring aligned with the did:oan Java driver instead of HTTP-only forwarding

This enables the did:oan method to be integrated as a first-class locally loaded resolver driver in the OAN universal-resolver fork.