### PR TITLE
Add driver for did:ixo

### DIFF
--- a/.env
+++ b/.env
@@ -85,3 +85,5 @@ uniresolver_driver_did_webplus_DID_WEBPLUS_URD_LISTEN_PORT=80
 uniresolver_driver_did_webplus_DID_WEBPLUS_URD_LOG_FORMAT=compact
 uniresolver_driver_did_webplus_RUST_BACKTRACE=1
 uniresolver_driver_did_webplus_RUST_LOG=did_webplus=info
+
+uniresolver_driver_did_ixo_rpc_endpoint=https://impacthub.ixo.world/rpc/

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ You should then be able to resolve identifiers locally using simple `curl` reque
 	curl -X GET http://localhost:8080/1.0/identifiers/did:nfd:nfdomains.algo
 	curl -X GET http://localhost:8080/1.0/identifiers/did:bluchain:issuer:9scF2JkUWfgcXhCdnn4QtBDkLFk5y4q5RD7316y8jEjR
 	curl -X GET http://localhost:8080/1.0/identifiers/did:webplus:ledgerdomain.github.io:did-webplus-spec:uFiANVlMledNFUBJNiZPuvfgzxvJlGGDBIpDFpM4DXW6Bow
+	curl -X GET http://localhost:8080/1.0/identifiers/did:ixo:ixo1rl9vhhxg0t7ywlh953gtthphg889v7d3e2gx7k
 
 
 You can also use an "Accept" header to request the DID document in a specific representation, e.g.:
@@ -209,6 +210,7 @@ Are you developing a DID method and Universal Resolver driver? Click [Driver Dev
 | [did-bluchain](https://gitlab.com/blucloud-public/did-driver-bluchain)                                        | 1.0.0          | [1.0.0](https://gitlab.com/blucloud-public/did-driver-bluchain/-/blob/master/README.md)                               | [bluchain/did-driver-bluchain](https://hub.docker.com/repository/docker/bluchain/did-driver-bluchain)                                                              | Bluchain DID                                                                        |
 | [did-webplus](https://github.com/LedgerDomain/did-webplus)                                                          | 0.1.1          | [0.4](https://ledgerdomain.github.io/did-webplus-spec/)                                         | [did-webplus-urd](ghcr.io/ledgerdomain/did-webplus-urd)                                                                    | webplus DID                                                                             |
 | [did-art](https://github.com/ArtracID/ArtracID-DID-ART-Method) | 1.0.0 | [spec](https://github.com/ArtracID/ArtracID-DID-ART-Method) | [worthyopponent30/did-art-resolver](https://hub.docker.com/r/worthyopponent30/did-art-resolver) | DID:ART for digital artwork |
+| [did-ixo](https://github.com/ixofoundation/ixo-did-resolver) | 0.1.5 | [1.0](https://ixofoundation.github.io/ns/did/v1/) | [ghcr.io/ixofoundation/ixo-did-resolver](https://github.com/ixofoundation/ixo-did-resolver/pkgs/container/ixo-did-resolver) | IXO Impact Hub network |
 
 
 ## More Information

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,6 +82,7 @@ services:
       uniresolver_web_driver_url_did_nfd:
       uniresolver_web_driver_url_did_bluchain:
       uniresolver_web_driver_url_did_webplus:
+      uniresolver_web_driver_url_did_ixo:
 
   driver-did-btcr:
     image: universalresolver/driver-did-btcr:latest
@@ -471,3 +472,10 @@ services:
       RUST_LOG: ${uniresolver_driver_did_webplus_RUST_LOG}
     ports:
       - "8168:80"
+
+  driver-did-ixo:
+    image: ghcr.io/ixofoundation/ixo-did-resolver:v0.1.5
+    environment:
+      RPC_ENDPOINT: ${uniresolver_driver_did_ixo_rpc_endpoint}
+    ports:
+      - "8181:8080"

--- a/uni-resolver-web/src/main/resources/application.yml
+++ b/uni-resolver-web/src/main/resources/application.yml
@@ -452,3 +452,14 @@ uniresolver:
       testIdentifiers:
         - did:webplus:ledgerdomain.github.io:did-webplus-spec:uFiANVlMledNFUBJNiZPuvfgzxvJlGGDBIpDFpM4DXW6Bow
         - did:webplus:ledgerdomain.github.io:did-webplus-spec:uFiDBw4xANa8sR_Fd8-pv-X9A5XIJNS3tC_bRNB3HUYiKug
+
+    - pattern: "^(did:ixo:.+)$"
+      url: ${uniresolver_web_driver_url_did_ixo:http://driver-did-ixo:8080/1.0/identifiers/$1}
+      acceptHeaderValue: application/did+ld+json
+      testIdentifiers:
+        - did:ixo:ixo1rl9vhhxg0t7ywlh953gtthphg889v7d3e2gx7k
+        - did:ixo:entity:00046b59059562e773694ea495bc1b23
+      traits:
+        deactivatable: true
+        updateable: true
+        humanReadable: false


### PR DESCRIPTION
## Summary

Adds a Universal Resolver driver for the **did:ixo** DID method — DIDs anchored on the [IXO Impact Hub](https://www.ixo.world/) network (a Cosmos SDK chain), covering account DIDs (`did:ixo:ixo1...`), entity DIDs (`did:ixo:entity:<32hex>`), and CosmWasm contract DIDs (`did:ixo:wasm:ixo1...`).

## Checklist per [driver development guide](https://github.com/decentralized-identity/universal-resolver/blob/main/docs/driver-development.md)

- **W3C DID Method Registry**: `did:ixo` is registered — approved and merged via [w3c/did-extensions#725](https://github.com/w3c/did-extensions/pull/725)
- **Method specification**: https://ixofoundation.github.io/ns/did/v1/ (JSON-LD context published at [`https://w3id.org/ixo/ns/did/v1`](https://w3id.org/ixo/ns/did/v1))
- **Driver source** (Apache 2.0): https://github.com/ixofoundation/ixo-did-resolver
- **Docker image** (versioned, publicly pullable, linux/amd64): `ghcr.io/ixofoundation/ixo-did-resolver:v0.1.5`
- **W3C DID Test Suite conformance**: 351/351 normative tests passing across did-identifier, did-production, did-core-properties, and did-resolution suites — evidence branch: [ixoworld/did-test-suite@ixo](https://github.com/ixoworld/did-test-suite/tree/ixo)
- **Hosted resolver** (same driver, production): https://resolver.ixo.world/1.0/identifiers/did:ixo:ixo1rl9vhhxg0t7ywlh953gtthphg889v7d3e2gx7k
- **Contact**: Michael Pretorius — michael@ixo.world / [@ixofoundation](https://github.com/ixofoundation)

## Files changed

- `docker-compose.yml` — `driver-did-ixo` service (port 8181) + web env passthrough
- `uni-resolver-web/src/main/resources/application.yml` — driver entry with pattern, `acceptHeaderValue`, test identifiers, traits
- `.env` — default Impact Hub RPC endpoint (operator-overridable)
- `README.md` — driver table row + curl example

## Tested

Built `uni-resolver-web` from this branch and ran it with the driver via docker compose; resolution verified end-to-end through the gateway:

```
GET /1.0/identifiers/did:ixo:ixo1rl9vhhxg0t7ywlh953gtthphg889v7d3e2gx7k  → 200 (DID resolution result)
GET /1.0/identifiers/did:ixo:entity:00046b59059562e773694ea495bc1b23     → 200
GET /1.0/identifiers/did:ixo:wasm:ixo10mdfdff64ee44tyzlqlnf6vh76f8gfd5g… → 200
GET /1.0/identifiers/did:ixo:doesnotexist…                               → 404 (notFound)
```

`/1.0/methods` lists `ixo` and `/1.0/testIdentifiers` returns both test DIDs. Both test identifiers are permanent mainnet DIDs maintained by the IXO Foundation.

Authored by: Michael Pretorius <michael@ixo.world>