### PR TITLE
feat: add driver for did:neuralkey method

### DIFF
--- a/.env
+++ b/.env
@@ -19,7 +19,7 @@ uniresolver_driver_did_work_domain=https://credentials.id.workday.com
 
 uniresolver_driver_kilt_blockchain_node=wss://spiritnet.kilt.io
 
-uniresolver_driver_dns_dnsServers=
+uniresolver_driver_dns_dnsServers= 
 
 uniresolver_driver_did_indy_libIndyPath=
 uniresolver_driver_did_indy_poolConfigs=sovrin;./sovrin/sovrin.txn;sovrin:test;./sovrin/sovrin-test.txn;sovrin:builder;./sovrin/sovrin-builder.txn;danube;./sovrin/danube.txn;indicio;./sovrin/indicio.txn;indicio:test;./sovrin/indicio-test.txn;indicio:demo;./sovrin/indicio-demo.txn;nxd;./sovrin/nxd.txn;findy:test;./sovrin/findy-test.txn

--- a/README.md
+++ b/README.md
@@ -210,6 +210,9 @@ Are you developing a DID method and Universal Resolver driver? Click [Driver Dev
 | [did-webplus](https://github.com/LedgerDomain/did-webplus)                                                          | 0.1.1          | [0.4](https://ledgerdomain.github.io/did-webplus-spec/)                                         | [did-webplus-urd](ghcr.io/ledgerdomain/did-webplus-urd)                                                                    | webplus DID                                                                             |
 | [did-art](https://github.com/ArtracID/ArtracID-DID-ART-Method) | 1.0.0 | [spec](https://github.com/ArtracID/ArtracID-DID-ART-Method) | [worthyopponent30/did-art-resolver](https://hub.docker.com/r/worthyopponent30/did-art-resolver) | DID:ART for digital artwork |
 
+| Method | Driver Version | Spec | Docker Image | Maintainer |
+| :--- | :--- | :--- | :--- | :--- |
+| `neuralkey` | `1.0.0` | [Spec Link](https://neuralkey.neuralsh.com/neuralkey-spec-page) | [heanmengfong/neuralkey-did-driver](https://hub.docker.com/r/heanmengfong/neuralkey-did-driver) | [Sereyvuth Kim/PRESTIGE ALLIANCE CO., LTD](https://neuralkey.neuralsh.com/) |
 
 ## More Information
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.6"
+# version: "3.6"
 
 networks:
   default:
@@ -82,6 +82,7 @@ services:
       uniresolver_web_driver_url_did_nfd:
       uniresolver_web_driver_url_did_bluchain:
       uniresolver_web_driver_url_did_webplus:
+      uniresolver_web_driver_url_did_neuralkey: 
 
   driver-did-btcr:
     image: universalresolver/driver-did-btcr:latest
@@ -375,7 +376,7 @@ services:
     ports:
       - "8154:8080"
   driver-did-quarkid:
-    image:  quarkid/api-proxy:latest
+    image: quarkid/api-proxy:latest
     ports:
       - 8155:8080
     environment:
@@ -431,13 +432,13 @@ services:
   driver-did-hedera:
     image: ghcr.io/hiero-ledger/uni-resolver-driver-did-hedera:v0.1.7-8ae3a53
     ports:
-        - "8165:8080"
+      - "8165:8080"
 
   driver-did-nda:
     image: ghcr.io/pilacorp/driver-did-nda:1.0.0
     ports:
       - "8166:8080"
-  
+
   driver-did-art:
     image: worthyopponent30/did-art-resolver:v1.0.0
     ports:
@@ -460,7 +461,7 @@ services:
       PORT: 8080
     ports:
       - "8168:8080"
-      
+
   driver-did-webplus:
     image: ghcr.io/ledgerdomain/did-webplus-urd:v0.1.2
     environment:
@@ -471,3 +472,8 @@ services:
       RUST_LOG: ${uniresolver_driver_did_webplus_RUST_LOG}
     ports:
       - "8168:80"
+
+  driver-did-neuralkey:
+    image: heanmengfong/neuralkey-did-driver:1.0.0
+    ports:
+      - "8169:8080"

--- a/uni-resolver-web/src/main/resources/application.yml
+++ b/uni-resolver-web/src/main/resources/application.yml
@@ -452,3 +452,9 @@ uniresolver:
       testIdentifiers:
         - did:webplus:ledgerdomain.github.io:did-webplus-spec:uFiANVlMledNFUBJNiZPuvfgzxvJlGGDBIpDFpM4DXW6Bow
         - did:webplus:ledgerdomain.github.io:did-webplus-spec:uFiDBw4xANa8sR_Fd8-pv-X9A5XIJNS3tC_bRNB3HUYiKug
+    
+    - pattern: "^(did:neuralkey:.+)$"
+      url: "${uniresolver_web_driver_url_did_neuralkey:http://driver-did-neuralkey:8080/1.0/identifiers/$1}"
+      testIdentifiers:
+        - "did:neuralkey:z6MkwAkLNUmKBRha3s2NzRWFFsDSXJ2QF44w9AT4CmSBuU41"
+        - "did:neuralkey:did-neuralsh.serveblog.net"


### PR DESCRIPTION
This PR introduces a new custom driver integration for the `did:neuralkey` method to the Universal Resolver. The driver is built as a lightweight, standalone TypeScript/Express service and containerized using an optimized multi-stage production build.

* **`docker-compose.yml`**: Appended the `driver-did-neuralkey` service and mapped the internal driver URL environment variable for `uni-resolver-web`.
* **`uni-resolver-web/src/main/resources/application.yml`**: Registered the regex pattern `^(did:neuralkey:.*)$` and added the appropriate test identifiers.
* **`README.md`**: Updated the driver capability matrix table to include the `neuralkey` method, specification link, and Docker Hub image repository.

* **Docker Hub:** The production-ready Docker image has been successfully built, tagged, and pushed to Docker Hub. It is publicly available for the Universal Resolver deployment.
* **Local Testing:** I have successfully verified the entire integration locally on my Docker machine by running `docker compose up`. The central `uni-resolver-web` core correctly identifies the `did:neuralkey` pattern, routes the traffic to the custom driver container, and yields a valid DID Document response flawlessly.

* **DID Method:** `neuralkey`
* **Docker Image:** heanmengfong/neuralkey-did-driver:1.0.0