### PR TITLE
Add did:cid driver (Archon Protocol)

### DIFF
--- a/.env
+++ b/.env
@@ -85,3 +85,6 @@ uniresolver_driver_did_webplus_DID_WEBPLUS_URD_LISTEN_PORT=80
 uniresolver_driver_did_webplus_DID_WEBPLUS_URD_LOG_FORMAT=compact
 uniresolver_driver_did_webplus_RUST_BACKTRACE=1
 uniresolver_driver_did_webplus_RUST_LOG=did_webplus=info
+
+# did:cid (Archon Protocol)
+uniresolver_driver_did_cid_gatekeeper_url=https://archon.technology

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ You should then be able to resolve identifiers locally using simple `curl` reque
 	curl -X GET http://localhost:8080/1.0/identifiers/did:nfd:nfdomains.algo
 	curl -X GET http://localhost:8080/1.0/identifiers/did:bluchain:issuer:9scF2JkUWfgcXhCdnn4QtBDkLFk5y4q5RD7316y8jEjR
 	curl -X GET http://localhost:8080/1.0/identifiers/did:webplus:ledgerdomain.github.io:did-webplus-spec:uFiANVlMledNFUBJNiZPuvfgzxvJlGGDBIpDFpM4DXW6Bow
+	curl -X GET http://localhost:8080/1.0/identifiers/did:cid:bagaaieraxdxq4fm2kjh6yqjxjor3t2idczkmxd4v7in4u353fa6m6sms2pnq
 
 
 You can also use an "Accept" header to request the DID document in a specific representation, e.g.:
@@ -209,6 +210,7 @@ Are you developing a DID method and Universal Resolver driver? Click [Driver Dev
 | [did-bluchain](https://gitlab.com/blucloud-public/did-driver-bluchain)                                        | 1.0.0          | [1.0.0](https://gitlab.com/blucloud-public/did-driver-bluchain/-/blob/master/README.md)                               | [bluchain/did-driver-bluchain](https://hub.docker.com/repository/docker/bluchain/did-driver-bluchain)                                                              | Bluchain DID                                                                        |
 | [did-webplus](https://github.com/LedgerDomain/did-webplus)                                                          | 0.1.1          | [0.4](https://ledgerdomain.github.io/did-webplus-spec/)                                         | [did-webplus-urd](ghcr.io/ledgerdomain/did-webplus-urd)                                                                    | webplus DID                                                                             |
 | [did-art](https://github.com/ArtracID/ArtracID-DID-ART-Method) | 1.0.0 | [spec](https://github.com/ArtracID/ArtracID-DID-ART-Method) | [worthyopponent30/did-art-resolver](https://hub.docker.com/r/worthyopponent30/did-art-resolver) | DID:ART for digital artwork |
+| [did-cid](https://github.com/archetech/uni-resolver-driver-did-cid) | 0.1.0 | [0.1.0](https://github.com/archetech/archon/blob/main/docs/scheme.md) | [ghcr.io/archetech/uni-resolver-driver-did-cid](https://github.com/archetech/uni-resolver-driver-did-cid/pkgs/container/uni-resolver-driver-did-cid) | Archon Protocol (content-addressed DID) |
 
 
 ## More Information

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,6 +82,7 @@ services:
       uniresolver_web_driver_url_did_nfd:
       uniresolver_web_driver_url_did_bluchain:
       uniresolver_web_driver_url_did_webplus:
+      uniresolver_web_driver_url_did_cid:
 
   driver-did-btcr:
     image: universalresolver/driver-did-btcr:latest
@@ -471,3 +472,10 @@ services:
       RUST_LOG: ${uniresolver_driver_did_webplus_RUST_LOG}
     ports:
       - "8168:80"
+
+  driver-did-cid:
+    image: ghcr.io/archetech/uni-resolver-driver-did-cid:0.1.0
+    environment:
+      ARCHON_GATEKEEPER_URL: ${uniresolver_driver_did_cid_gatekeeper_url}
+    ports:
+      - "4250:4250"

--- a/uni-resolver-web/src/main/resources/application.yml
+++ b/uni-resolver-web/src/main/resources/application.yml
@@ -452,3 +452,9 @@ uniresolver:
       testIdentifiers:
         - did:webplus:ledgerdomain.github.io:did-webplus-spec:uFiANVlMledNFUBJNiZPuvfgzxvJlGGDBIpDFpM4DXW6Bow
         - did:webplus:ledgerdomain.github.io:did-webplus-spec:uFiDBw4xANa8sR_Fd8-pv-X9A5XIJNS3tC_bRNB3HUYiKug
+
+    - pattern: "^(did:cid:.+)$"
+      url: ${uniresolver_web_driver_url_did_cid:http://driver-did-cid:4250/1.0/identifiers/$1}
+      testIdentifiers:
+        - did:cid:bagaaieraxdxq4fm2kjh6yqjxjor3t2idczkmxd4v7in4u353fa6m6sms2pnq
+        - did:cid:bagaaierajzwcicueqdkbgk75lgekdmvtbo5zv3spq2p4f7d7ow42urlwi32a


### PR DESCRIPTION

## Summary

This PR adds a Universal Resolver driver for the **did:cid** method used by the
[Archon Protocol](https://archon.technology). `did:cid` is a content-addressed DID method whose
identifier is derived from the IPFS CID of the genesis DID document, making it self-certifying and
instantly creatable (no on-chain transaction required). The driver resolves a `did:cid` by proxying
to an Archon **gatekeeper** node and returns a W3C
[DID Resolution Result](https://w3c.github.io/did-resolution/#did-resolution-result).

- **Method:** `did:cid`
- **Spec:** https://github.com/archetech/archon/blob/main/docs/scheme.md
- **Driver source:** https://github.com/archetech/uni-resolver-driver-did-cid
- **Image:** `ghcr.io/archetech/uni-resolver-driver-did-cid:0.1.0`

## Changes

This is a configuration-only PR; the driver source and image are hosted externally (standard
driver layout). Per [`docs/driver-development.md`](docs/driver-development.md), it updates:

- `docker-compose.yml` — `driver-did-cid` service + an empty `uniresolver_web_driver_url_did_cid:`
  override under the `uni-resolver-web` service environment.
- `uni-resolver-web/src/main/resources/application.yml` — driver `pattern`, `url` placeholder, and
  `testIdentifiers`.
- `.env` — default `uniresolver_driver_did_cid_gatekeeper_url=https://archon.technology`.
- `README.md` — row added to the driver table.

## Example DIDs

```
did:cid:bagaaieraxdxq4fm2kjh6yqjxjor3t2idczkmxd4v7in4u353fa6m6sms2pnq
did:cid:bagaaierajzwcicueqdkbgk75lgekdmvtbo5zv3spq2p4f7d7ow42urlwi32a
```

## Driver Rules checklist

- [x] Driver exposes the standard HTTP interface `GET /1.0/identifiers/<did>`.
- [x] Driver source code is publicly available under a permissive license (Apache 2.0).
- [x] Docker image version is pinned (`0.1.0`), not `:latest`.
- [x] Contact information provided (see below).
- [x] Tested standalone and via `docker compose`.
- [x] **DID method registered in the W3C DID Method Registry.** `did:cid` is listed in
      [DID Extensions — Methods](https://www.w3.org/TR/did-extensions-methods/).
- [x] **Docker image published to a public registry.**
      `ghcr.io/archetech/uni-resolver-driver-did-cid:0.1.0` is published and publicly pullable
      (verified with an unauthenticated `docker pull`). Built and pushed by
      [`.github/workflows/publish.yml`](https://github.com/archetech/uni-resolver-driver-did-cid/blob/main/.github/workflows/publish.yml)
      in the driver repo.

## Testing

```bash
# Standalone (from the driver repo: github.com/archetech/uni-resolver-driver-did-cid)
docker build -t ghcr.io/archetech/uni-resolver-driver-did-cid:0.1.0 .
docker run -p 4250:4250 -e ARCHON_GATEKEEPER_URL=https://archon.technology \
  ghcr.io/archetech/uni-resolver-driver-did-cid:0.1.0
curl http://localhost:4250/1.0/identifiers/did:cid:bagaaieraxdxq4fm2kjh6yqjxjor3t2idczkmxd4v7in4u353fa6m6sms2pnq

# Via the resolver
docker compose -f docker-compose.yml up -d uni-resolver-web driver-did-cid
curl http://localhost:8080/1.0/identifiers/did:cid:bagaaieraxdxq4fm2kjh6yqjxjor3t2idczkmxd4v7in4u353fa6m6sms2pnq
```

## Contact

- **Maintainer:** Archetech (Archon Protocol)
- **GitHub:** https://github.com/archetech/archon
- **Email:** flaxscrip@pm.me
