### PR TITLE
Add did:stellar driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ You should then be able to resolve identifiers locally using simple `curl` reque
 	curl -X GET http://localhost:8080/1.0/identifiers/did:bluchain:issuer:9scF2JkUWfgcXhCdnn4QtBDkLFk5y4q5RD7316y8jEjR
 	curl -X GET http://localhost:8080/1.0/identifiers/did:webplus:ledgerdomain.github.io:did-webplus-spec:uFiANVlMledNFUBJNiZPuvfgzxvJlGGDBIpDFpM4DXW6Bow
 	curl -X GET http://localhost:8080/1.0/identifiers/did:cid:bagaaieraxdxq4fm2kjh6yqjxjor3t2idczkmxd4v7in4u353fa6m6sms2pnq
+	curl -X GET http://localhost:8080/1.0/identifiers/did:stellar:testnet:32dhec37woze2mkfpnorosw5ma
 
 
 You can also use an "Accept" header to request the DID document in a specific representation, e.g.:
@@ -211,6 +212,7 @@ Are you developing a DID method and Universal Resolver driver? Click [Driver Dev
 | [did-webplus](https://github.com/LedgerDomain/did-webplus)                                                          | 0.1.1          | [0.4](https://ledgerdomain.github.io/did-webplus-spec/)                                         | [did-webplus-urd](ghcr.io/ledgerdomain/did-webplus-urd)                                                                    | webplus DID                                                                             |
 | [did-art](https://github.com/ArtracID/ArtracID-DID-ART-Method) | 1.0.0 | [spec](https://github.com/ArtracID/ArtracID-DID-ART-Method) | [worthyopponent30/did-art-resolver](https://hub.docker.com/r/worthyopponent30/did-art-resolver) | DID:ART for digital artwork |
 | [did-cid](https://github.com/archetech/uni-resolver-driver-did-cid) | 0.1.0 | [0.1.0](https://github.com/archetech/archon/blob/main/docs/scheme.md) | [ghcr.io/archetech/uni-resolver-driver-did-cid](https://github.com/archetech/uni-resolver-driver-did-cid/pkgs/container/uni-resolver-driver-did-cid) | Archon Protocol (content-addressed DID) |
+| [did-stellar](https://github.com/ACTA-Team/did-stellar)                                                             | 0.1.0          | [0.1](https://github.com/ACTA-Team/contracts-acta/blob/main/docs/did-spec/did-stellar-v0.1.md)                    | [ghcr.io/acta-team/driver-did-stellar](https://github.com/orgs/ACTA-Team/packages/container/package/driver-did-stellar)                                            | Stellar / Soroban DID Method                                                        |
 
 
 ## More Information

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ You should then be able to resolve identifiers locally using simple `curl` reque
 	curl -X GET http://localhost:8080/1.0/identifiers/did:nfd:nfdomains.algo
 	curl -X GET http://localhost:8080/1.0/identifiers/did:bluchain:issuer:9scF2JkUWfgcXhCdnn4QtBDkLFk5y4q5RD7316y8jEjR
 	curl -X GET http://localhost:8080/1.0/identifiers/did:webplus:ledgerdomain.github.io:did-webplus-spec:uFiANVlMledNFUBJNiZPuvfgzxvJlGGDBIpDFpM4DXW6Bow
+	curl -X GET http://localhost:8080/1.0/identifiers/did:stellar:testnet:32dhec37woze2mkfpnorosw5ma
 
 
 You can also use an "Accept" header to request the DID document in a specific representation, e.g.:
@@ -209,6 +210,7 @@ Are you developing a DID method and Universal Resolver driver? Click [Driver Dev
 | [did-bluchain](https://gitlab.com/blucloud-public/did-driver-bluchain)                                        | 1.0.0          | [1.0.0](https://gitlab.com/blucloud-public/did-driver-bluchain/-/blob/master/README.md)                               | [bluchain/did-driver-bluchain](https://hub.docker.com/repository/docker/bluchain/did-driver-bluchain)                                                              | Bluchain DID                                                                        |
 | [did-webplus](https://github.com/LedgerDomain/did-webplus)                                                          | 0.1.1          | [0.4](https://ledgerdomain.github.io/did-webplus-spec/)                                         | [did-webplus-urd](ghcr.io/ledgerdomain/did-webplus-urd)                                                                    | webplus DID                                                                             |
 | [did-art](https://github.com/ArtracID/ArtracID-DID-ART-Method) | 1.0.0 | [spec](https://github.com/ArtracID/ArtracID-DID-ART-Method) | [worthyopponent30/did-art-resolver](https://hub.docker.com/r/worthyopponent30/did-art-resolver) | DID:ART for digital artwork |
+| [did-stellar](https://github.com/ACTA-Team/did-stellar)                                                             | 0.1.0          | [0.1](https://github.com/ACTA-Team/contracts-acta/blob/main/docs/did-spec/did-stellar-v0.1.md)                    | [ghcr.io/acta-team/driver-did-stellar](https://github.com/orgs/ACTA-Team/packages/container/package/driver-did-stellar)                                            | Stellar / Soroban DID Method                                                        |
 
 
 ## More Information

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,6 +83,7 @@ services:
       uniresolver_web_driver_url_did_bluchain:
       uniresolver_web_driver_url_did_webplus:
       uniresolver_web_driver_url_did_cid:
+      uniresolver_web_driver_url_did_stellar:
 
   driver-did-btcr:
     image: universalresolver/driver-did-btcr:latest
@@ -475,3 +476,8 @@ services:
       ARCHON_GATEKEEPER_URL: ${uniresolver_driver_did_cid_gatekeeper_url}
     ports:
       - "4250:4250"
+
+  driver-did-stellar:
+    image: ghcr.io/acta-team/driver-did-stellar:0.1.0
+    ports:
+      - "8169:8080"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,6 +82,7 @@ services:
       uniresolver_web_driver_url_did_nfd:
       uniresolver_web_driver_url_did_bluchain:
       uniresolver_web_driver_url_did_webplus:
+      uniresolver_web_driver_url_did_stellar:
 
   driver-did-btcr:
     image: universalresolver/driver-did-btcr:latest
@@ -471,3 +472,8 @@ services:
       RUST_LOG: ${uniresolver_driver_did_webplus_RUST_LOG}
     ports:
       - "8168:80"
+
+  driver-did-stellar:
+    image: ghcr.io/acta-team/driver-did-stellar:0.1.0
+    ports:
+      - "8169:8080"

--- a/uni-resolver-web/src/main/resources/application.yml
+++ b/uni-resolver-web/src/main/resources/application.yml
@@ -456,3 +456,14 @@ uniresolver:
       testIdentifiers:
         - did:cid:bagaaieraxdxq4fm2kjh6yqjxjor3t2idczkmxd4v7in4u353fa6m6sms2pnq
         - did:cid:bagaaierajzwcicueqdkbgk75lgekdmvtbo5zv3spq2p4f7d7ow42urlwi32a
+
+    - pattern: "^(did:stellar:.+)$"
+      url: ${uniresolver_web_driver_url_did_stellar:http://driver-did-stellar:8080/1.0/identifiers/$1}
+      testIdentifiers:
+        - did:stellar:testnet:32dhec37woze2mkfpnorosw5ma
+        - did:stellar:mainnet:6wr5l6d33bwa32olkiwret35yu
+      traits:
+        deactivatable: true
+        enumerable: false
+        historyAvailable: false
+        humanReadable: false

--- a/uni-resolver-web/src/main/resources/application.yml
+++ b/uni-resolver-web/src/main/resources/application.yml
@@ -452,3 +452,14 @@ uniresolver:
       testIdentifiers:
         - did:webplus:ledgerdomain.github.io:did-webplus-spec:uFiANVlMledNFUBJNiZPuvfgzxvJlGGDBIpDFpM4DXW6Bow
         - did:webplus:ledgerdomain.github.io:did-webplus-spec:uFiDBw4xANa8sR_Fd8-pv-X9A5XIJNS3tC_bRNB3HUYiKug
+
+    - pattern: "^(did:stellar:.+)$"
+      url: ${uniresolver_web_driver_url_did_stellar:http://driver-did-stellar:8080/1.0/identifiers/$1}
+      testIdentifiers:
+        - did:stellar:testnet:32dhec37woze2mkfpnorosw5ma
+        - did:stellar:mainnet:6wr5l6d33bwa32olkiwret35yu
+      traits:
+        deactivatable: true
+        enumerable: false
+        historyAvailable: false
+        humanReadable: false


### PR DESCRIPTION
# Add `did:stellar` driver

This PR adds a Universal Resolver driver for the **`did:stellar`** DID method, which anchors decentralized identifiers on the [Stellar](https://stellar.org) network via a [Soroban](https://developers.stellar.org/docs/build/smart-contracts) smart contract registry.

`did:stellar` is registered in the [W3C DID Extensions Method Registry](https://www.w3.org/TR/did-extensions-methods/). The registration was merged in [w3c/did-extensions#729](https://github.com/w3c/did-extensions/pull/729).

---

## Method summary

| | |
|---|---|
| **Method name** | `stellar` |
| **Method spec** | [did:stellar v0.1](https://github.com/ACTA-Team/contracts-acta/blob/main/docs/did-spec/did-stellar-v0.1.md) |
| **Verifiable Data Registry** | Stellar network + the canonical `did-stellar-registry` Soroban contract |
| **W3C registry status** | `registered` ([w3c/did-extensions#729](https://github.com/w3c/did-extensions/pull/729), merged) |
| **Registry contract (testnet)** | [`CB7ATU7SF5QUKJMSULJDJVWJZVDXC23HTZX6NFUDTSFPVT6MA575NNZJ`](https://stellar.expert/explorer/testnet/contract/CB7ATU7SF5QUKJMSULJDJVWJZVDXC23HTZX6NFUDTSFPVT6MA575NNZJ) |
| **Registry contract (mainnet)** | [`CD6LSWW5ZSXOO5WAIHKQLQ262TW7BPI37PNEVMMA273BAPC65NN2AYXQ`](https://stellar.expert/explorer/public/contract/CD6LSWW5ZSXOO5WAIHKQLQ262TW7BPI37PNEVMMA273BAPC65NN2AYXQ) |

### Identifier syntax

```
did:stellar:<network>:<identifier>

did:stellar:testnet:32dhec37woze2mkfpnorosw5ma
did:stellar:mainnet:6wr5l6d33bwa32olkiwret35yu
```

The network segment (`testnet` | `mainnet`) is part of the identifier, so a single driver instance serves both networks and routes each request to the corresponding registry contract. There is no network-selection configuration to get wrong.

### Background

`did:stellar` was developed by [ACTA](https://acta.build) at the request of the Stellar Development Foundation to provide an official DID method for the Stellar ecosystem. It supports wallet-independent identifiers, controller-authorized lifecycle management, on-chain key rotation, and issuance and verification of W3C Verifiable Credentials. The specification defines the DID syntax, the full Create / Read / Update / Deactivate operation set, and includes both Security Considerations and Privacy Considerations sections, as attested in the W3C registration.

---

## Driver

| | |
|---|---|
| **Driver name** | `did-stellar` |
| **Driver version** | `0.1.0` |
| **DID method spec version** | `0.1` |
| **Docker image** | [`ghcr.io/acta-team/driver-did-stellar:0.1.0`](https://github.com/orgs/ACTA-Team/packages/container/package/driver-did-stellar) |
| **Source** | [github.com/ACTA-Team/did-stellar](https://github.com/ACTA-Team/did-stellar) (`packages/api`) |
| **License** | [Apache-2.0](https://github.com/ACTA-Team/did-stellar/blob/main/LICENSE) |
| **Maintainer** | ACTA Team |
| **Contact** | acta.xyz@gmail.com · [github.com/ACTA-Team](https://github.com/ACTA-Team) |

The image is published to **GHCR rather than Docker Hub** deliberately: the driver development guidelines call out Docker Hub's anonymous-pull rate limits as a cause of driver removal, and GHCR imposes no such limit on public packages.

Publication is automated: [`.github/workflows/docker.yml`](https://github.com/ACTA-Team/did-stellar/blob/main/.github/workflows/docker.yml) builds and pushes the image with provenance and SBOM attestations, then boots the pushed image and asserts that both `/health` and `GET /1.0/identifiers/{did}` respond before the run is allowed to succeed. A broken image cannot reach a release.

### Configuration

**None required.** The driver starts with no environment variables and falls back to the public Stellar RPC endpoints and the published registry contract IDs for both networks. This is why no entry was added to `.env`.

Operators who prefer a private RPC provider may optionally set `STELLAR_RPC_URL_TESTNET`, `STELLAR_RPC_URL_MAINNET`, `DID_REGISTRY_CONTRACT_ID_TESTNET` or `DID_REGISTRY_CONTRACT_ID_MAINNET`; each is independently optional and empty values are ignored.

### Resolution behaviour

- `GET /1.0/identifiers/{did}` returns a DID Resolution Result.
- Content negotiation between `application/did+ld+json` (default) and `application/did+json`.
- `404` for an unknown identifier; `410 Gone` for a deactivated (tombstoned) DID.
- Resolution reads directly from Stellar RPC and the registry contract. The driver holds no keys, requires no credentials, and depends on no ACTA-operated infrastructure. A third party can run it standalone and obtain identical results.

---

## Changes in this PR

| File | Change |
|---|---|
| `docker-compose.yml` | Adds the `driver-did-stellar` service on port `8169`, and registers `uniresolver_web_driver_url_did_stellar` in the `uni-resolver-web` environment block |
| `uni-resolver-web/src/main/resources/application.yml` | Adds the `^(did:stellar:.+)$` pattern with its driver URL, test identifiers and traits |
| `README.md` | Adds the driver table row and a `curl` example |

`.env` is intentionally untouched: the driver requires no configuration, so there are no defaults to declare.

### Test identifiers

```yaml
- pattern: "^(did:stellar:.+)$"
  url: ${uniresolver_web_driver_url_did_stellar:http://driver-did-stellar:8080/1.0/identifiers/$1}
  testIdentifiers:
    - did:stellar:testnet:32dhec37woze2mkfpnorosw5ma
    - did:stellar:mainnet:6wr5l6d33bwa32olkiwret35yu
  traits:
    deactivatable: true
    enumerable: false
    historyAvailable: false
    humanReadable: false
```

Both identifiers are live, active DIDs anchored on-chain, one per network, so the pair exercises the driver's network routing rather than a single code path.

---

## Verification performed

The driver was tested **both standalone and inside the Universal Resolver via `docker-compose`**, as required by the driver development guidelines.

**1. Image is publicly pullable, unauthenticated**

Verified from a clean state. The local copy was deleted and re-pulled with no credentials, reproducing what CI does:

```
$ docker logout ghcr.io
$ docker rmi ghcr.io/acta-team/driver-did-stellar:0.1.0
$ docker pull ghcr.io/acta-team/driver-did-stellar:0.1.0
Digest: sha256:5431e0b50f8b880cf96a0a487bd1402aff666fc17dcb89a0c80140d449c814c9
Status: Downloaded newer image
```

**2. Standalone container**

```
$ docker run -p 8080:8080 ghcr.io/acta-team/driver-did-stellar:0.1.0

GET /health                                              → 200
GET /1.0/identifiers/did:stellar:testnet:32dhec...       → 200  application/did+ld+json
GET /1.0/identifiers/<nonexistent>                       → 404
```

**3. Through the Universal Resolver (`docker compose up uni-resolver-web driver-did-stellar`)**

```
GET /1.0/methods           → "stellar" present
GET /1.0/testIdentifiers   → both identifiers listed
GET /1.0/traits            → ^(did:stellar:.+)$ present with its traits

GET /1.0/identifiers/did:stellar:testnet:32dhec37woze2mkfpnorosw5ma  → 200, id matches
GET /1.0/identifiers/did:stellar:mainnet:6wr5l6d33bwa32olkiwret35yu  → 200, id matches
Accept: application/did+ld+json                                      → 200, correct content-type
```

Port `8169` was chosen as the next free host port; no conflict with existing services.

---

## Driver rules compliance

- [x] The DID method has a specification registered in the W3C DID Method Registry ([w3c/did-extensions#729](https://github.com/w3c/did-extensions/pull/729), merged)
- [x] Driver code is publicly available and fully open source under a permissive license (Apache-2.0, the license the driver guidelines list as preferred)
- [x] Contact information provided (email and GitHub organization)
- [x] Image published on a publicly accessible container registry (GHCR), pullable anonymously
- [x] An explicit version tag is referenced: `0.1.0`, not `latest`
- [x] Tested standalone and within the Universal Resolver via `docker-compose`
- [x] Documented: method specification, driver README, API reference, error codes and configuration reference are all public

### Maintenance

The ACTA Team maintains this driver and will respond to issues raised against it. The publishing workflow is automated and gated on a live smoke test of the pushed image, so version bumps are reproducible and a non-functional image cannot be released. Contact: acta.xyz@gmail.com.

---

## Reference

- Method specification: https://github.com/ACTA-Team/contracts-acta/blob/main/docs/did-spec/did-stellar-v0.1.md
- W3C registration PR: https://github.com/w3c/did-extensions/pull/729
- W3C DID Method Registry: https://www.w3.org/TR/did-extensions-methods/
- Driver source: https://github.com/ACTA-Team/did-stellar
- Container image: https://github.com/orgs/ACTA-Team/packages/container/package/driver-did-stellar
- Public reference deployment: https://did.acta.build ([Swagger UI](https://did.acta.build/docs))


