### PR TITLE
Add driver for did:mst method

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       # See https://docs.docker.com/compose/compose-file/05-services/#environment
       uniresolver_web_driver_url_did_btcr:
       uniresolver_web_driver_url_did_sov:
+      uniresolver_web_driver_url_did_mst: http://driver-did-mst:8080/
       uniresolver_web_driver_url_did_indy:
       uniresolver_web_driver_url_did_v1_nym:
       uniresolver_web_driver_url_did_v1_test_nym:
@@ -182,6 +183,16 @@ services:
     image: ghcr.io/gataca-io/universal-resolver-driver/universal-resolver-driver:3.0.0
     ports:
       - "8113:8080"
+
+  driver-did-mst:
+    image: navinjoshimongoosetech/driver-did-mst:latest
+    ports:
+      - "8086:8080"
+    environment:
+      - MST_RPC_URL=${uniresolver_driver_did_mst_rpc_url}
+      - MST_REGISTRY_ADDRESS=${uniresolver_driver_did_mst_registry_address}
+      - MST_CHAIN_ID=${uniresolver_driver_did_mst_chain_id}
+  
   driver-did-icon:
     image: amuyu/driver-did-icon:0.1.3
     environment:

--- a/driver-did-mst/Dockerfile
+++ b/driver-did-mst/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package.json .
+RUN npm install
+
+COPY index.js .
+
+EXPOSE 8080
+
+CMD ["node", "index.js"]

--- a/driver-did-mst/Readme.md
+++ b/driver-did-mst/Readme.md
@@ -1,0 +1,100 @@
+# did:mst Driver
+
+This driver resolves `did:mst` identifiers by reading DID documents from the MST blockchain testnet registry contract.
+
+## Example
+
+```
+did:mst:testnet:0x3b0BC51Ab9De1e5B7B6E34E5b960285805C41736
+```
+
+## Build and Run
+
+This driver is implemented in Node.js.
+
+```bash
+docker build -t driver-did-mst .
+docker run -p 8080:8080 \
+  -e MST_RPC_URL=https://testnetrpc.mstblockchain.com \
+  -e MST_REGISTRY_ADDRESS=0xCdceF2336831C45202dCd739BDcF3D0661E342c7 \
+  -e MST_CHAIN_ID=4545 \
+  driver-did-mst
+```
+
+## Docker Image
+
+A prebuilt image is available on Docker Hub:
+
+```
+navinjoshimongoosetech/driver-did-mst:latest
+```
+
+## Environment Variables
+
+| Variable | Description |
+|---|---|
+| `MST_RPC_URL` | RPC endpoint for the MST testnet |
+| `MST_REGISTRY_ADDRESS` | Address of the DID registry smart contract |
+| `MST_CHAIN_ID` | Chain ID of the MST testnet |
+
+## Resolving
+
+```
+curl http://localhost:8080/1.0/identifiers/did:mst:testnet:0x3b0BC51Ab9De1e5B7B6E34E5b960285805C41736
+```
+
+Example response:
+
+```json
+{
+  "didDocument": {
+    "@context": [
+      "https://www.w3.org/ns/did/v1",
+      "https://w3id.org/security/suites/secp256k1recovery-2020/v2"
+    ],
+    "id": "did:mst:testnet:0x3b0BC51Ab9De1e5B7B6E34E5b960285805C41736",
+    "controller": "did:mst:testnet:0x3b0BC51Ab9De1e5B7B6E34E5b960285805C41736",
+    "verificationMethod": [
+      {
+        "id": "did:mst:testnet:0x3b0BC51Ab9De1e5B7B6E34E5b960285805C41736#controller",
+        "type": "EcdsaSecp256k1RecoveryMethod2020",
+        "controller": "did:mst:testnet:0x3b0BC51Ab9De1e5B7B6E34E5b960285805C41736",
+        "blockchainAccountId": "eip155:4545:0x3b0BC51Ab9De1e5B7B6E34E5b960285805C41736"
+      }
+    ],
+    "authentication": [
+      "did:mst:testnet:0x3b0BC51Ab9De1e5B7B6E34E5b960285805C41736#controller"
+    ],
+    "assertionMethod": [
+      "did:mst:testnet:0x3b0BC51Ab9De1e5B7B6E34E5b960285805C41736#controller"
+    ]
+  },
+  "didResolutionMetadata": {
+    "contentType": "application/did+ld+json",
+    "network": "testnet",
+    "registry": "0xCdceF2336831C45202dCd739BDcF3D0661E342c7"
+  },
+  "didDocumentMetadata": {
+    "lastChangedBlock": "0"
+  }
+}
+```
+
+## Network Support
+
+Currently supports **testnet** only. Mainnet support may be added in a future release.
+
+## Driver Environment Variables
+
+This driver uses the following environment variables in `docker-compose.yml`:
+
+```yaml
+driver-did-mst:
+  image: navinjoshimongoosetech/driver-did-mst:latest
+  ports:
+    - "8086:8080"
+  environment:
+    - MST_RPC_URL=${uniresolver_driver_did_mst_rpc_url}
+    - MST_REGISTRY_ADDRESS=${uniresolver_driver_did_mst_registry_address}
+    - MST_CHAIN_ID=${uniresolver_driver_did_mst_chain_id}
+```

--- a/driver-did-mst/index.js
+++ b/driver-did-mst/index.js
@@ -1,0 +1,103 @@
+const express = require('express');
+const { ethers } = require('ethers');
+
+const app = express();
+const PORT = process.env.PORT || 8080;
+
+// MST Testnet config
+const MST_TESTNET_RPC = process.env.MST_RPC_URL; // set to actual MST testnet RPC endpoint
+const REGISTRY_CONTRACT_ADDRESS = process.env.MST_REGISTRY_ADDRESS || "0xCdceF2336831C45202dCd739BDcF3D0661E342c7";
+const CHAIN_ID = process.env.MST_CHAIN_ID || "mst-testnet"; // used inside blockchainAccountId (eip155:<chainId>)
+
+// Standard ERC-1056 EthereumDIDRegistry ABI (only the read functions we need)
+const REGISTRY_ABI = [
+  "function identityOwner(address identity) view returns (address)",
+  "function changed(address identity) view returns (uint256)",
+  "function nonce(address identity) view returns (uint256)"
+];
+
+if (!MST_TESTNET_RPC) {
+  console.warn("WARNING: MST_RPC_URL is not set. Set it to the MST Testnet JSON-RPC endpoint.");
+}
+
+const provider = new ethers.JsonRpcProvider(MST_TESTNET_RPC);
+const registry = new ethers.Contract(REGISTRY_CONTRACT_ADDRESS, REGISTRY_ABI, provider);
+
+app.get('/1.0/identifiers/:did', async (req, res) => {
+  const did = req.params.did;
+
+  // Expected format: did:mst:testnet:0xADDRESS
+  const parts = did.split(':');
+  if (parts[0] !== 'did' || parts[1] !== 'mst' || parts.length < 4) {
+    return res.status(400).json({
+      didResolutionMetadata: { error: 'invalidDid', message: `Unsupported DID format: ${did}` },
+      didDocument: null,
+      didDocumentMetadata: {}
+    });
+  }
+
+  const network = parts[2];       // testnet / mainnet
+  const address = parts[3];       // 0x... identity address
+
+  if (!ethers.isAddress(address)) {
+    return res.status(400).json({
+      didResolutionMetadata: { error: 'invalidDid', message: `Invalid Ethereum-style address: ${address}` },
+      didDocument: null,
+      didDocumentMetadata: {}
+    });
+  }
+
+  try {
+    const owner = await registry.identityOwner(address);
+    const lastChanged = await registry.changed(address);
+
+    const didDocument = {
+      "@context": [
+        "https://www.w3.org/ns/did/v1",
+        "https://w3id.org/security/suites/secp256k1recovery-2020/v2"
+      ],
+      id: did,
+      controller: did,
+      verificationMethod: [
+        {
+          id: `${did}#controller`,
+          type: "EcdsaSecp256k1RecoveryMethod2020",
+          controller: did,
+          blockchainAccountId: `eip155:${CHAIN_ID}:${owner}`
+        }
+      ],
+      authentication: [`${did}#controller`],
+      assertionMethod: [`${did}#controller`]
+    };
+
+    return res.json({
+      didDocument,
+      didResolutionMetadata: {
+        contentType: "application/did+ld+json",
+        network,
+        registry: REGISTRY_CONTRACT_ADDRESS
+      },
+      didDocumentMetadata: {
+        // block number of the last change event on-chain, useful for auditing/caching
+        lastChangedBlock: lastChanged.toString()
+      }
+    });
+
+  } catch (err) {
+    console.error(`Resolution failed for ${did}:`, err.message);
+    return res.status(404).json({
+      didResolutionMetadata: { error: 'notFound', message: err.message },
+      didDocument: null,
+      didDocumentMetadata: {}
+    });
+  }
+});
+
+// simple health check, useful once this sits behind Universal Resolver / docker-compose
+app.get('/health', (req, res) => res.json({ status: 'ok' }));
+
+app.listen(PORT, () => {
+  console.log(`did:mst driver running on port ${PORT}`);
+  console.log(`Registry: ${REGISTRY_CONTRACT_ADDRESS}`);
+  console.log(`RPC: ${MST_TESTNET_RPC || '(not set!)'}`);
+});

--- a/driver-did-mst/package.json
+++ b/driver-did-mst/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "driver-did-mst",
+  "version": "1.0.0",
+  "main": "index.js",
+  "dependencies": {
+    "express": "^4.19.2",
+    "ethers": "^6.13.0"
+  }
+}


### PR DESCRIPTION
This PR adds a driver for the did:mst DID method, supporting resolution on the MST testnet.

## What this does
- Adds a `driver-did-mst` service to docker-compose.yml
- Registers the `did:mst` method with uni-resolver-web via `uniresolver_web_driver_url_did_mst`
- Adds a README for the driver at driver-did-mst/README.md

## Docker Image
navinjoshimongoosetech/driver-did-mst:latest

## Tested resolution
curl http://localhost:8087/1.0/identifiers/did:mst:testnet:0x3b0BC51Ab9De1e5B7B6E34E5b960285805C41736

Returns a valid DID document with verificationMethod, authentication, and assertionMethod.

## Network support
Currently supports testnet only.